### PR TITLE
Implement inverse prefix lookup, plus tests

### DIFF
--- a/src/prefix/tests.rs
+++ b/src/prefix/tests.rs
@@ -1,5 +1,6 @@
 #[cfg(test)] extern crate reqwest;
 use super::PrefixSet;
+use fst::raw;
 
 #[test]
 fn test() {
@@ -38,6 +39,24 @@ fn test() {
             pf.contains_prefix(prefix)
         }),
         "PrefixSet contains prefixes of all words as prefixes"
+    );
+
+    assert!(
+        words_with_ids.iter().all(|ref t| {
+            match pf.get_by_id(raw::Output::new(t.1)) {
+                Some(v) => match String::from_utf8(v) {
+                    Ok(s) => s == t.0,
+                    _ => false
+                },
+                None => false
+            }
+        }),
+        "PrefixSet inverse lookups return the expected result"
+    );
+
+    assert!(
+        pf.get_by_id(raw::Output::new(words.len() as u64)).is_none(),
+        "PrefixSet inverse lookup returns none on out of bounds lookup"
     );
 
     let be_subset: Vec<(String, u64)> = words_with_ids.iter().filter(|ref t| t.0.starts_with("be")).cloned().collect();


### PR DESCRIPTION
I added a mechanism for backwards lookup of the prefix tree (id => text). There's some awkwardness, still:
* to maintain symmetry with the functions that go the other way (text => id), I made the input be an `fst::raw::Output` type, but it means you have to construct an Output before you can start. There's no function overloading in Rust, so that may just be how it goes (or we can sacrifice symmetry and operate on integers, whichever).
* the output is a `Vec<u8>` instead of a String. Think we'll just have to live with that one though, as invalid unicode is allowed to exist in the structure.

Basic algorithmic approach is:
* treat our ID as the budget of value we have left to "spend" on transitions
* set current node to root
* set output to an empty vector
* loop:
    * examine the transitions of the current node
    * find the first transition whose output is greater than the ID value we have left, and select the preceding transition as the one to proceed along (or proceed along the last transition if we don't find a greater-than one)
    * add the selected transition's input to the output vector and subtract its output from the ID budget
    * If the budget is zero and our current node is final, return the output vector
* bail (`return None`) if:
    * our budget falls below 0
    * we run out of nodes/transitions