### PR TITLE
Return ranges of the form [x,y) instead of [x,y]

### DIFF
--- a/src/prefix/mod.rs
+++ b/src/prefix/mod.rs
@@ -40,7 +40,7 @@ impl PrefixSet {
             out = out.cat(t.out);
             node = fst.node(t.addr);
         }
-        Some((start, out.cat(node.final_output())))
+        Some((start, out.cat(node.final_output()).cat(raw::Output::new(1))))
     }
 
     pub fn get_by_id(&self, id: raw::Output) -> Option<Vec<u8>> {

--- a/src/prefix/tests.rs
+++ b/src/prefix/tests.rs
@@ -63,7 +63,7 @@ fn test() {
     let be_range = pf.get_prefix_range("be").unwrap();
     assert_eq!(
         (be_range.0.value(), be_range.1.value()),
-        (be_subset[0].1, be_subset.last().unwrap().1),
+        (be_subset[0].1, be_subset.last().unwrap().1 + 1),
         "Prefix range for string 'be' behaves as expected"
     );
 


### PR DESCRIPTION
Per chat, we'll stick with ranges that are exclusive on the top end to be consistent with earlier code and the standard Rust range flavor (`..`).