### PR TITLE
Add utility function for int <-> byte-array

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Andrew Pendleton <andrew@mapbox.com>"]
 
 [dependencies]
 fst = "0.3.0"
+byteorder = "1.2.2"
 
 [dev-dependencies]
 reqwest = "0.8.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,5 @@ extern crate byteorder;
 mod prefix;
 pub use prefix::PrefixSet;
 pub use prefix::PrefixSetBuilder;
+
+pub mod phrase;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate fst;
+extern crate byteorder;
 
 mod prefix;
 pub use prefix::PrefixSet;

--- a/src/phrase/mod.rs
+++ b/src/phrase/mod.rs
@@ -1,0 +1,1 @@
+pub mod util;

--- a/src/phrase/util.rs
+++ b/src/phrase/util.rs
@@ -10,9 +10,7 @@ pub fn chop_int(num: u64) -> Vec<u8> {
 pub fn three_byte_encode(num: u64) -> Vec<u8> {
     let mut byte_vec: Vec<u8> = Vec::new();
     let chopped: Vec<u8> = chop_int(num);
-    byte_vec.push(chopped[5]);
-    byte_vec.push(chopped[6]);
-    byte_vec.push(chopped[7]);
+    byte_vec.extend_from_slice(&chopped.as_slice()[5..8]);
     byte_vec
 }
 

--- a/src/phrase/util.rs
+++ b/src/phrase/util.rs
@@ -8,15 +8,14 @@ pub fn chop_int(num: u64) -> Vec<u8> {
 }
 
 pub fn three_byte_encode(num: u64) -> Vec<u8> {
-    let mut byte_vec: Vec<u8> = Vec::new();
     let chopped: Vec<u8> = chop_int(num);
-    byte_vec.extend_from_slice(&chopped.as_slice()[5..8]);
-    byte_vec
+    let three_bytes: Vec<u8> = chopped[5..8].to_vec();
+    three_bytes
 }
 
-pub fn three_byte_decode(byte_vec: &[u8]) -> u64 {
+pub fn three_byte_decode(three_bytes: &[u8]) -> u64 {
     let mut padded_byte_vec: Vec<u8> = vec![0u8; 5];
-    padded_byte_vec.extend_from_slice(byte_vec);
+    padded_byte_vec.extend_from_slice(three_bytes);
     let mut reader = Cursor::new(padded_byte_vec);
     reader.read_u64::<BigEndian>().unwrap()
 }

--- a/src/phrase/util.rs
+++ b/src/phrase/util.rs
@@ -14,11 +14,9 @@ pub fn three_byte_encode(num: u64) -> Vec<u8> {
     byte_vec
 }
 
-pub fn three_byte_decode(byte_vec: Vec<u8>) -> u64 {
+pub fn three_byte_decode(byte_vec: &[u8]) -> u64 {
     let mut padded_byte_vec: Vec<u8> = vec![0u8; 5];
-    for b in byte_vec.into_iter() {
-        padded_byte_vec.push(b);
-    }
+    padded_byte_vec.extend_from_slice(byte_vec);
     let mut reader = Cursor::new(padded_byte_vec);
     reader.read_u64::<BigEndian>().unwrap()
 }
@@ -94,7 +92,7 @@ mod tests {
     #[test]
     fn three_bytes_to_large_integer() {
         let three_bytes: Vec<u8> = vec![ 8u8, 145u8, 120u8];
-        let n: u64 = three_byte_decode(three_bytes);
+        let n: u64 = three_byte_decode(&three_bytes);
         assert_eq!(
             561_528u64,
             n

--- a/src/phrase/util.rs
+++ b/src/phrase/util.rs
@@ -1,0 +1,107 @@
+use std::io::Cursor;
+use byteorder::{BigEndian, WriteBytesExt, ReadBytesExt};
+
+pub fn chop_int(num: u64) -> Vec<u8> {
+    let mut wtr = vec![];
+    wtr.write_u64::<BigEndian>(num).unwrap();
+    wtr
+}
+
+pub fn three_byte_encode(num: u64) -> Vec<u8> {
+    let mut byte_vec: Vec<u8> = Vec::new();
+    let chopped: Vec<u8> = chop_int(num);
+    byte_vec.push(chopped[5]);
+    byte_vec.push(chopped[6]);
+    byte_vec.push(chopped[7]);
+    byte_vec
+}
+
+pub fn three_byte_decode(byte_vec: Vec<u8>) -> u64 {
+    let mut padded_byte_vec: Vec<u8> = vec![0u8; 5];
+    for b in byte_vec.into_iter() {
+        padded_byte_vec.push(b);
+    }
+    let mut reader = Cursor::new(padded_byte_vec);
+    reader.read_u64::<BigEndian>().unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn byte_literals_demo() {
+        let x: u8 = 255;
+
+        assert_eq!(0b1111_1111, x);
+
+        let s = format!("{:b}", x);
+        assert_eq!("11111111", s);
+
+        let y: u8 = 0;
+        assert_eq!(0b0000_0000, y);
+        assert_eq!(0b________0, y);
+
+        let max64: u64 = u64::max_value();
+        assert_eq!(18_446_744_073_709_551_615, max64);
+    }
+
+    #[test]
+    fn chop_smallest_int_to_bytes() {
+        let n: u64 = u64::min_value();
+        let chopped: Vec<u8> = chop_int(n);
+        assert_eq!(
+            vec![0u8, 0u8, 0u8, 0u8,
+                 0u8, 0u8, 0u8, 0u8],
+            chopped
+        );
+
+    }
+
+    #[test]
+    fn chop_largest_int_to_bytes() {
+        let n: u64 = u64::max_value();
+        let chopped: Vec<u8> = chop_int(n);
+        assert_eq!(
+            vec![255u8, 255u8, 255u8, 255u8,
+                 255u8, 255u8, 255u8, 255u8],
+            chopped
+        );
+    }
+
+    #[test]
+    fn chop_big_int_to_bytes() {
+        // first value larger than u32::max_value(), aka 2**32
+        let n: u64 = 4_294_967_296;
+        let chopped: Vec<u8> = chop_int(n);
+        assert_eq!(
+            vec![0u8, 0u8, 0u8, 1u8,
+                 0u8, 0u8, 0u8, 0u8],
+            chopped
+        );
+    }
+
+    #[test]
+    fn large_integer_to_three_bytes() {
+        // the number we're using is arbitrary. happens to be the number of distinct words in
+        // us-address, so gives us an idea of the cardinality we're dealing with.
+        let n: u64 = 561_528;
+        let three_bytes: Vec<u8> = three_byte_encode(n);
+        assert_eq!(
+            vec![ 8u8, 145u8, 120u8],
+            three_bytes
+        );
+    }
+
+    #[test]
+    fn three_bytes_to_large_integer() {
+        let three_bytes: Vec<u8> = vec![ 8u8, 145u8, 120u8];
+        let n: u64 = three_byte_decode(three_bytes);
+        assert_eq!(
+            561_528u64,
+            n
+        );
+    }
+
+}
+

--- a/src/phrase/util.rs
+++ b/src/phrase/util.rs
@@ -26,23 +26,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn byte_literals_demo() {
-        let x: u8 = 255;
-
-        assert_eq!(0b1111_1111, x);
-
-        let s = format!("{:b}", x);
-        assert_eq!("11111111", s);
-
-        let y: u8 = 0;
-        assert_eq!(0b0000_0000, y);
-        assert_eq!(0b________0, y);
-
-        let max64: u64 = u64::max_value();
-        assert_eq!(18_446_744_073_709_551_615, max64);
-    }
-
-    #[test]
     fn chop_smallest_int_to_bytes() {
         let n: u64 = u64::min_value();
         let chopped: Vec<u8> = chop_int(n);


### PR DESCRIPTION
This PR provides utility functions for building the phrase graph. The words associated with final states in the word graph will each be associated with an integer. `fst::raw::Transition` only allows byte (`u8`) inputs, however. To build the phrase graph, then, we'll represent each word as a fixed-length byte array.  

Length two would only allow 2**16 = 65,536 entries, and that's probably too small.  The number of unique tokens in a corpus can easily be in the hundreds of thousands.

This uses three bytes, giving us 2**24 = 16,777,216 entries, which is most likely overkill.