### PR TITLE
Fix mmap-related stuff for prefix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,13 @@ authors = ["Andrew Pendleton <andrew@mapbox.com>"]
 fst = "0.3.0"
 byteorder = "1.2.2"
 
+[dependencies.memmap]
+version = "0.6.0"
+optional = true
+
 [dev-dependencies]
 reqwest = "0.8.5"
+
+[features]
+default = ["mmap"]
+mmap = ["memmap"]

--- a/src/prefix/boilerplate.rs
+++ b/src/prefix/boilerplate.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 use std::io::prelude::*;
+#[cfg(feature = "mmap")]
+use std::path::Path;
 use fst::{IntoStreamer, Streamer};
 use fst::raw;
 use fst::Error as FstError;


### PR DESCRIPTION
Appropriate some mmap-related config stuff from upstream fst.