### PR TITLE
Robust symspell implementation built on top of fst

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["Andrew Pendleton <andrew@mapbox.com>"]
 fst = "0.3.0"
 memmap = "0.6.2"
 itertools = "0.7.8"
+serde = "1.0.37"
+rmp-serde = "0.13.7"
+serde_derive = "1.0.37"
 
 [dev-dependencies]
 reqwest = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,22 +5,19 @@ authors = ["Andrew Pendleton <andrew@mapbox.com>"]
 
 [dependencies]
 fst = "0.3.0"
-memmap = "0.6.2"
 itertools = "0.7.8"
 serde = "1.0.37"
 rmp-serde = "0.13.7"
 serde_derive = "1.0.37"
+strsim = "0.7.0"
+byteorder = "1.2.2"
 
 [dev-dependencies]
 reqwest = "0.8.5"
-byteorder = "1.2.2"
 
 [dependencies.memmap]
 version = "0.6.0"
 optional = true
-
-[dev-dependencies]
-reqwest = "0.8.5"
 
 [features]
 default = ["mmap"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Andrew Pendleton <andrew@mapbox.com>"]
 
 [dependencies]
 fst = "0.3.0"
+memmap = "0.6.2"
+itertools = "0.7.8"
 
 [dev-dependencies]
 reqwest = "0.8.5"

--- a/src/fuzzy/map.rs
+++ b/src/fuzzy/map.rs
@@ -1,0 +1,108 @@
+use fst::{IntoStreamer, Streamer, Set, Map, MapBuilder, Automaton};
+use std::fmt;
+use std::io::prelude::*;
+use fst::raw;
+use fst::Error as FstError;
+use fst::automaton::{AlwaysMatch};
+
+
+pub struct FuzzySetBuilder<W> {
+    builder: raw::Builder<W>
+}
+
+impl FuzzySetBuilder<Vec<u8>> {
+    pub fn memory() -> Self {
+        FuzzySetBuilder { builder: raw::Builder::memory() }
+    }
+}
+
+impl<W: Write> FuzzySetBuilder<W> {
+    pub fn new(fst_wtr: W) -> Result<FuzzySetBuilder<W>, FstError> {
+        Ok(FuzzySetBuilder { builder: raw::Builder::new_type(fst_wtr, 0)? })
+    }
+
+    pub fn insert<K: AsRef<[u8]>>(&mut self, key: K, ids: u64) -> Result<(), FstError> {
+        self.builder.insert(key, ids)?;
+        Ok(())
+    }
+
+    pub fn finish(self) -> Result<(), FstError> {
+        self.builder.finish()
+    }
+
+    pub fn into_inner(self) -> Result<W, FstError> {
+        self.builder.into_inner()
+    }
+
+    pub fn get_ref(&self) -> &W {
+        self.builder.get_ref()
+    }
+
+    pub fn bytes_written(&self) -> u64 {
+        self.builder.bytes_written()
+    }
+}
+
+pub struct Stream<'s, A=AlwaysMatch>(raw::Stream<'s, A>) where A: Automaton;
+
+impl<'s, A: Automaton> Stream<'s, A> {
+    #[doc(hidden)]
+    pub fn new(fst_stream: raw::Stream<'s, A>) -> Self {
+        Stream(fst_stream)
+    }
+
+    pub fn into_byte_vec(self) -> Vec<(Vec<u8>, u64)> {
+        self.0.into_byte_vec()
+    }
+
+    pub fn into_str_vec(self) -> Result<Vec<(String, u64)>, FstError> {
+        self.0.into_str_vec()
+    }
+
+    pub fn into_strs(self) -> Result<Vec<String>, FstError> {
+        self.0.into_str_keys()
+    }
+
+    pub fn into_bytes(self) -> Vec<Vec<u8>> {
+        self.0.into_byte_keys()
+    }
+}
+
+impl<'a, 's, A: Automaton> Streamer<'a> for Stream<'s, A> {
+    type Item = (&'a [u8], u64);
+
+    fn next(&'a mut self) -> Option<Self::Item> {
+        self.0.next().map(|(key, out)| (key, out.value()))
+    }
+}
+
+pub struct StreamBuilder<'s, A=AlwaysMatch>(raw::StreamBuilder<'s, A>);
+
+impl<'s, A: Automaton> StreamBuilder<'s, A> {
+    pub fn ge<T: AsRef<[u8]>>(self, bound: T) -> Self {
+        StreamBuilder(self.0.ge(bound))
+    }
+
+    pub fn gt<T: AsRef<[u8]>>(self, bound: T) -> Self {
+        StreamBuilder(self.0.gt(bound))
+    }
+
+    pub fn le<T: AsRef<[u8]>>(self, bound: T) -> Self {
+        StreamBuilder(self.0.le(bound))
+    }
+
+    pub fn lt<T: AsRef<[u8]>>(self, bound: T) -> Self {
+        StreamBuilder(self.0.lt(bound))
+    }
+}
+
+impl<'s, 'a, A: Automaton> IntoStreamer<'a> for StreamBuilder<'s, A> {
+    type Item = (&'a [u8], u64);
+    type Into = Stream<'s, A>;
+
+    fn into_stream(self) -> Self::Into {
+        Stream(self.0.into_stream())
+    }
+}
+
+fn main() {}

--- a/src/fuzzy/map.rs
+++ b/src/fuzzy/map.rs
@@ -82,7 +82,9 @@ impl<W: Write> FuzzyMapBuilder<W> {
 
     pub fn extend_iter<T, I>(&mut self, iter: I) -> Result<(), FstError>
             where T: AsRef<[u8]>, I: IntoIterator<Item=(T, u64)> {
-                self.builder.extend_iter(iter.into_iter().map(|(k, v)| (k, raw::Output::new(v))));
+                for (k, v) in iter {
+                    self.builder.insert(k, v)?;
+                }
                 Ok(())
     }
 

--- a/src/fuzzy/map.rs
+++ b/src/fuzzy/map.rs
@@ -19,12 +19,12 @@ impl FuzzyMap {
         raw::Fst::from_bytes(bytes).map(FuzzyMap)
     }
 
-    // pub fn from_iter<T, I>(iter: I) -> Result<Self, FstError>
-    //         where T: AsRef<[u8]>, I: IntoIterator<Item=T> {
-    //     let mut builder = FuzzyMapBuilder::memory();
-    //     builder.extend_iter(iter)?;
-    //     FuzzyMap::from_bytes(builder.into_inner()?)
-    // }
+    pub fn from_iter<T, I>(iter: I) -> Result<Self, FstError>
+            where T: AsRef<[u8]>, I: IntoIterator<Item=(T, u64)> {
+        let mut builder = FuzzyMapBuilder::memory();
+        builder.extend_iter(iter)?;
+        FuzzyMap::from_bytes(builder.into_inner()?)
+    }
 
     pub fn contains<K: AsRef<[u8]>>(&self, key: K) -> bool {
         self.0.contains_key(key)
@@ -78,6 +78,12 @@ impl<W: Write> FuzzyMapBuilder<W> {
     pub fn insert<K: AsRef<[u8]>>(&mut self, key: K, ids: u64) -> Result<(), FstError> {
         self.builder.insert(key, ids)?;
         Ok(())
+    }
+
+    pub fn extend_iter<T, I>(&mut self, iter: I) -> Result<(), FstError>
+            where T: AsRef<[u8]>, I: IntoIterator<Item=(T, u64)> {
+                self.builder.extend_iter(iter.into_iter().map(|(k, v)| (k, raw::Output::new(v))));
+                Ok(())
     }
 
     pub fn finish(self) -> Result<(), FstError> {

--- a/src/fuzzy/map.rs
+++ b/src/fuzzy/map.rs
@@ -1,5 +1,4 @@
 use fst::{IntoStreamer, Streamer, Set, Map, MapBuilder, Automaton};
-use std::fmt;
 use std::io::prelude::*;
 use fst::raw;
 use fst::Error as FstError;
@@ -104,5 +103,3 @@ impl<'s, 'a, A: Automaton> IntoStreamer<'a> for StreamBuilder<'s, A> {
         Stream(self.0.into_stream())
     }
 }
-
-fn main() {}

--- a/src/fuzzy/mod.rs
+++ b/src/fuzzy/mod.rs
@@ -4,8 +4,8 @@ use std::io::{self, Write};
 use std::fs::File;
 use std::error::Error;
 use itertools::Itertools;
-use std::io::Read;
-use memmap::Mmap;
+use serde::{Deserialize, Serialize};
+use rmps::{Deserializer, Serializer};
 
 mod map;
 pub use self::map::FuzzySetBuilder;
@@ -33,8 +33,10 @@ impl IntoIterator for VectorCollection {
     }
 }
 
+#[derive(Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone)]
 struct Symspell {
-    word_list: Vec<String>,
+    // word_list: Vec<String>,
     id_list: Vec<Vec<usize>>
 }
 
@@ -53,14 +55,13 @@ impl Symspell {
                 multids.push((&opts).iter().map(|t| t.1).collect::<Vec<_>>());
                 multids.len() - 1 + BIG_NUMBER
             };
-            println!("{:?}", key);
+
+            let multi_idx = Symspell { id_list: multids.to_vec() };
+            let mut mf_wtr = BufWriter::new(File::create("id.msg")?);
+            multi_idx.serialize(&mut Serializer::new(mf_wtr))?;
             build.insert(key, id as u64);
         }
         build.finish()?;
-        println!("Done building structure!");
-        println!("{:?}", multids);
-        let mut file = File::open("x_sym.fst")?;
-        let mmap = unsafe { Mmap::map(&file).expect("failed to write to disk") };
         Ok(())
     }
     //creates delete variants for every word in the list
@@ -81,6 +82,7 @@ impl Symspell {
         word_variants.sort();
         word_variants
     }
+    fn lookup() {}
 }
 
 #[test]

--- a/src/fuzzy/mod.rs
+++ b/src/fuzzy/mod.rs
@@ -1,12 +1,8 @@
-// use fst::{IntoStreamer, Streamer, Set, Map, MapBuilder, Automaton};
 use std::io::{BufReader, BufWriter};
-use std::io::prelude::*;
-// use std::io::{Write};
 use std::fs::File;
 use std::error::Error;
 use itertools::Itertools;
-// use strsim::levenshtein;
-// use std::iter::once;
+use strsim::damerau_levenshtein;
 use serde::{Deserialize, Serialize};
 use rmps::{Deserializer, Serializer};
 
@@ -17,30 +13,10 @@ pub use self::map::FuzzyMap;
 static BIG_NUMBER: usize = 1 << 30;
 
 #[cfg(test)] extern crate reqwest;
-
-#[derive(Debug)]
-struct VectorCollection(Vec<String>);
-
-impl VectorCollection {
-    fn new() -> VectorCollection {
-        VectorCollection(Vec::new())
-    }
-}
-
-// and we'll implement IntoIterator
-impl IntoIterator for VectorCollection {
-    type Item = u8;
-    type IntoIter = ::std::vec::IntoIter<u8>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.into_iter()
-    }
-}
-
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 #[derive(Clone)]
+
 struct Symspell {
-    word_list: Option<Vec<String>>,
     id_list: Vec<Vec<usize>>
 }
 
@@ -59,15 +35,16 @@ impl Symspell {
                 multids.push((&opts).iter().map(|t| t.1).collect::<Vec<_>>());
                 multids.len() - 1 + BIG_NUMBER
             };
-            build.insert(key, id as u64);
+            build.insert(key, id as u64)?;
         }
-        let multi_idx = Symspell { word_list: None, id_list: multids.to_vec() };
-        let mut mf_wtr = BufWriter::new(File::create("id.msg")?);
+        let multi_idx = Symspell { id_list: multids.to_vec() };
+        let mf_wtr = BufWriter::new(File::create("id.msg")?);
         multi_idx.serialize(&mut Serializer::new(mf_wtr))?;
         build.finish()?;
         Ok(())
     }
     //creates delete variants for every word in the list
+    //using usize for - https://stackoverflow.com/questions/29592256/whats-the-difference-between-usize-and-u32?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa
     fn create_variants<'a, T>(words: T) -> Vec<(String, usize)> where T: IntoIterator<Item=&'a &'a str> {
         let mut word_variants = Vec::<(String, usize)>::new();
         //treating &words as a slice, since, slices are read-only objects
@@ -86,7 +63,8 @@ impl Symspell {
         word_variants
     }
 
-    fn lookup(query: &str) -> Result<(), Box<Error>> {
+    //Defining lifetimes here because we are expecting the string to last the lifetime of the closure F
+    fn lookup<'a, F>(query: &str, lookup_fn: F) -> Result<Vec<String>, Box<Error>> where F: Fn(usize) -> &'a str {
 
         let mut query_variants = Vec::new();
         let mut matches = Vec::<usize>::new();
@@ -95,6 +73,7 @@ impl Symspell {
         let map = unsafe { FuzzyMap::from_path("x_sym.fst")? };
 
         //create variants of the query itself
+        query_variants.push(query.to_owned());
         for (j, _) in query.char_indices() {
             let mut variant = String::with_capacity(query.len() - 1);
             let parts = query.split_at(j);
@@ -105,7 +84,7 @@ impl Symspell {
 
         let mf : Symspell;
         let mf_file = File::open("id.msg")?;
-        let mut mf_reader = BufReader::new(mf_file);
+        let mf_reader = BufReader::new(mf_file);
         mf = Deserialize::deserialize(&mut Deserializer::new(mf_reader))?;
 
         for i in query_variants {
@@ -123,30 +102,30 @@ impl Symspell {
                 None => {}
             }
         }
+        //return all ids that match
         matches.sort();
-        Ok(())
+
+        //checks all words whose damerau levenshtein edit distance is lesser than 2
+        Ok(matches
+            .into_iter().dedup()
+            .map(lookup_fn)
+            .filter(|word| damerau_levenshtein(query, word) < 2)
+            .map(|word| word.to_owned())
+            .collect::<Vec<String>>()
+        )
     }
 }
 
 #[test]
-fn structure_building() {
+fn exact_match() {
+    //the original word in the data is - "ALBAZAN"
+    let query = "lbazan";
     let data = reqwest::get("https://raw.githubusercontent.com/BurntSushi/fst/master/data/words-10000")
-       .expect("tried to download data")
-       .text().expect("tried to decode the data");
+    .expect("tried to download data")
+    .text().expect("tried to decode the data");
     let mut words = data.trim().split("\n").collect::<Vec<&str>>();
     words.sort();
-    let built = Symspell::build(&words);
+    let _built = Symspell::build(&words);
+    let matches = Symspell::lookup(&query, |id| &words[id]);
+    assert_eq!(matches.unwrap(), ["albazan"]);
 }
-#[test]
-fn reader() {
-    let query = "albazan";
-    let data = reqwest::get("https://raw.githubusercontent.com/BurntSushi/fst/master/data/words-10000")
-       .expect("tried to download data")
-       .text().expect("tried to decode the data");
-    let mut words = data.trim().split("\n").collect::<Vec<&str>>();
-    words.sort();
-    let matches = || Symspell::lookup(&query);
-    println!("{:?}", matches);
-}
-
-fn main() {}

--- a/src/fuzzy/mod.rs
+++ b/src/fuzzy/mod.rs
@@ -1,8 +1,68 @@
-extern crate fst;
-use fst::{IntoStreamer, Streamer, Set, Map, MapBuilder, Automaton};
+//use fst::{IntoStreamer, Streamer, Set, Map, MapBuilder, Automaton};
+use std::*;
+#[cfg(test)] extern crate reqwest;
+
+
+#[derive(Debug)]
+struct VectorCollection(Vec<String>);
+
+impl VectorCollection {
+    fn new() -> VectorCollection {
+        VectorCollection(Vec::new())
+    }
+}
+
+// and we'll implement IntoIterator
+impl IntoIterator for VectorCollection {
+    type Item = u8;
+    type IntoIter = ::std::vec::IntoIter<u8>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.into_iter()
+    }
+}
 
 struct Symspell {
-    map: &Map,
-    words: &Vec<String>,
-    id: &Vec<Vec<usize>>
+    word_list: Vec<String>,
+    id_list: Vec<Vec<usize>>
+}
+
+impl Symspell {
+    // will only build the structure
+    fn build(&self) {
+        println!("{:?}, {:?}", self.word_list, self.id_list);
+    }
+    //creates delete variants for every word in the list
+    fn create_variants<T>(words: T) -> Vec<(String, usize)> where T: IntoIterator {
+
+        let mut word_variants = Vec::<(String, usize)>::new();
+        //treating &words as a slice, since, slices are read-only objects
+        for (i, &word) in words.into_iter().enumerate() {
+        //let x: () = (*word).to_owned();
+            word_variants.push((word.to_owned(), i));
+            for (j, _) in word.char_indices() {
+                let mut s = String::with_capacity(word.len() - 1);
+                let parts = word.split_at(j);
+                s.push_str(parts.0);
+                s.extend(parts.1.chars().skip(1));
+                word_variants.push((s, i));
+            }
+        }
+        word_variants.sort();
+        word_variants
+    }
+}
+
+#[test]
+fn use_symspell() {
+    let data = reqwest::get("https://raw.githubusercontent.com/BurntSushi/fst/master/data/words-10000")
+       .expect("tried to download data")
+       .text().expect("tried to decode the data");
+    let mut words = data.trim().split("\n").collect::<Vec<&str>>();
+    words.sort();
+    //create variants
+    Symspell::create_variants(&words);
+}
+
+fn main() {
 }

--- a/src/fuzzy/mod.rs
+++ b/src/fuzzy/mod.rs
@@ -1,0 +1,8 @@
+extern crate fst;
+use fst::{IntoStreamer, Streamer, Set, Map, MapBuilder, Automaton};
+
+struct Symspell {
+    map: &Map,
+    words: &Vec<String>,
+    id: &Vec<Vec<usize>>
+}

--- a/src/fuzzy/mod.rs
+++ b/src/fuzzy/mod.rs
@@ -33,7 +33,7 @@ impl Symspell {
         println!("{:?}, {:?}", self.word_list, self.id_list);
     }
     //creates delete variants for every word in the list
-    fn create_variants<T>(words: T) -> Vec<(String, usize)> where T: IntoIterator {
+    fn create_variants<'a, T>(words: T) -> Vec<(String, usize)> where T: IntoIterator<Item=&'a &'a str> {
 
         let mut word_variants = Vec::<(String, usize)>::new();
         //treating &words as a slice, since, slices are read-only objects

--- a/src/fuzzy/mod.rs
+++ b/src/fuzzy/mod.rs
@@ -55,12 +55,11 @@ impl Symspell {
                 multids.push((&opts).iter().map(|t| t.1).collect::<Vec<_>>());
                 multids.len() - 1 + BIG_NUMBER
             };
-
-            let multi_idx = Symspell { id_list: multids.to_vec() };
-            let mut mf_wtr = BufWriter::new(File::create("id.msg")?);
-            multi_idx.serialize(&mut Serializer::new(mf_wtr))?;
             build.insert(key, id as u64);
         }
+        let multi_idx = Symspell { id_list: multids.to_vec() };
+        let mut mf_wtr = BufWriter::new(File::create("id.msg")?);
+        multi_idx.serialize(&mut Serializer::new(mf_wtr))?;
         build.finish()?;
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,5 @@ extern crate fst;
 mod prefix;
 pub use prefix::PrefixSet;
 pub use prefix::PrefixSetBuilder;
+
+mod fuzzy;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,10 @@
 extern crate fst;
 extern crate itertools;
 extern crate memmap;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate rmp_serde as rmps;
 
 mod prefix;
 pub use prefix::PrefixSet;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,15 +2,17 @@ extern crate fst;
 extern crate itertools;
 extern crate memmap;
 extern crate serde;
+extern crate strsim;
+extern crate byteorder;
 #[macro_use]
 extern crate serde_derive;
 extern crate rmp_serde as rmps;
-extern crate byteorder;
 
 mod prefix;
 pub use prefix::PrefixSet;
 pub use prefix::PrefixSetBuilder;
 
 mod fuzzy;
-pub use fuzzy::FuzzySetBuilder;
+pub use fuzzy::FuzzyMap;
+pub use fuzzy::FuzzyMapBuilder;
 pub mod phrase;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,11 @@
 extern crate fst;
+extern crate itertools;
+extern crate memmap;
 
 mod prefix;
 pub use prefix::PrefixSet;
 pub use prefix::PrefixSetBuilder;
 
 mod fuzzy;
+pub use fuzzy::FuzzySetBuilder;
+


### PR DESCRIPTION
### Context: 
Implement [Symspell algorithm](https://github.com/wolfgarbe/SymSpell) to work with [rust-fst](https://github.com/BurntSushi/fst). 

### Progress: 
- [x] Build out an actual type that implements d=1 case
- [x] Decide on an edit distance metric (probably one of Levenshtein or Damerau-Levenshtein) and document why you picked it. **(Picked Damerau for now since the original algorithm uses that too, will benchmark speeds when I write out the benchmarks)**
- [x] Write tests that confirm that it's working right and that are runnable using the cargo test runner

### Next Actions: 
- [ ] Build out type that implements d=2 case
- [ ] Benchmarks  
- [ ] Tests for: 
      - lookups of d=1 misspelled words
      -  lookups of words that are in the structure but also match misspellings at d=1
      -  unicode
      -  lookups for words that are not in the structure, and whose misspellings are not in the structure either
     -  garbage input: empty strings, giant strings, etc.

cc @apendleton, @aaaandrea, @boblannon 