### PR TITLE
Add script for profiling a benchmark on OSX

### DIFF
--- a/profile_osx.sh
+++ b/profile_osx.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# if current build profile doesn't include debug symbols, temporarily add
+# config to include them
+if [[ $(grep profile.release Cargo.toml | wc -l) -eq 0 ]]; then
+    cp Cargo.toml Cargo.toml-$$
+    printf "\n\n[profile.release]\ndebug = true" >> Cargo.toml
+fi
+
+# build the benchmarks
+cargo bench --no-run $1
+# find the build benchmark
+BUILD=$(ls -t target/release/benchmarks* | grep -v "\.d$" | head -n 1)
+# run benchmark, modified from http://carol-nichols.com/2017/04/20/rust-profiling-with-dtrace-on-osx/
+sudo dtrace -c "./$BUILD $1" -o out-$$.stacks -n 'profile-997 /pid == $target/ { @[ustack(100)] = count(); }'
+
+if [ ! -d '/tmp/FlameGraph' ]; then
+    git clone https://github.com/brendangregg/FlameGraph /tmp/FlameGraph
+fi
+
+/tmp/FlameGraph/stackcollapse.pl out-$$.stacks | /tmp/FlameGraph/flamegraph.pl > graph-$$.svg
+open graph-$$.svg -a "/Applications/Google Chrome.app/"
+
+# if we mangled Cargo.toml, put it back
+if [ -f Cargo.toml-$$ ]; then
+    mv Cargo.toml-$$ Cargo.toml
+fi


### PR DESCRIPTION
This PR adds a kind-of-hacky script for running benchmarks through a profiler. The idea is that you'd write a benchmark runnable through `cargo bench` (see https://github.com/mapbox/fuzzy-phrase/pull/4 ), but you'd run it through this script instead, which would build a special profile-able build of the bench suite, run your benchmark under a profiler, make a pretty interactive graph out of it, and then open it for you. For example, I wrote a prefix benchmark as part of #4 called `prefix/get_by_id`, and running it with the script like this:

```
$ ./profile_osx.sh prefix/get_by_id
```

produces an interactive flamegraph like this (which I've drilled down to the function I care about):

![fuzzy-profile](https://user-images.githubusercontent.com/78930/39548643-415f5760-4e29-11e8-980f-ade28603b5e5.png)

For the moment, I've only written a script that uses `dtrace` for profiling, mostly inspired by [this blog post](http://carol-nichols.com/2017/04/20/rust-profiling-with-dtrace-on-osx/). `dtrace` works on Macs (and also *BSD, Solaris, and some other stuff) but not Linux, so at some point it might be good to extend the script (or write a similar one) that accomplishes the same objective using a Linux profiling tool like `perf`, perhaps looking at [this other blog post](https://blog.anp.lol/rust/2016/07/24/profiling-rust-perf-flamegraph/) for inspiration, but I think I'm going to stick with this for now and figure that can be a stretch goal later for a future PR.