### PR TITLE
Coverage using Codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,12 +27,6 @@ jobs:
           paths:
             - "~/.cargo"
             - "./target"
-  coverage:
-    docker:
-      - image: circleci/rust:1.26
-    steps:
-      - restore_cache:
-          key: build-{{ .Branch }}-{{ checksum "Cargo.toml" }}
       - run:
           name: Coverage
           command: |
@@ -41,12 +35,3 @@ jobs:
               --ciserver circle-ci \
               --skip-clean --out Xml
             bash <(curl -s https://codecov.io/bash)
-
-workflows:
-  version: 2
-  build-and-test:
-    jobs:
-      - build
-      - coverage:
-          requires:
-            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,5 +36,5 @@ jobs:
             bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
             cargo tarpaulin \
               --ciserver circle-ci \
-              --skip-clean --out Xml
+              --verbose --out Xml
             bash <(curl -s https://codecov.io/bash)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,3 +27,26 @@ jobs:
           paths:
             - "~/.cargo"
             - "./target"
+  coverage:
+    docker:
+      - image: circleci/rust:1.26
+    steps:
+      - restore_cache:
+          key: build-{{ .Branch }}-{{ checksum "Cargo.toml" }}
+      - run:
+          name: Coverage
+          command: |
+            bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
+            cargo tarpaulin \
+              --ciserver circle-ci \
+              --skip-clean --out Xml
+            bash <(curl -s https://codecov.io/bash)
+
+workflows:
+  version: 2
+  build-and-test:
+    jobs:
+      - build
+      - coverage:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,13 @@ machine:
 jobs:
   build:
     docker:
-      - image: circleci/rust:1.26
+      - image: circleci/rust:1.26.0-jessie
     steps:
       - setup-docker-engine
       - checkout
+      - run:
+          name: Symlink Cargo
+          command: ln -s /usr/local/cargo ~/.cargo
       - restore_cache:
           key: build-{{ .Branch }}-{{ checksum "Cargo.toml" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: Symlink Cargo
           command: ln -s /usr/local/cargo ~/.cargo
       - restore_cache:
-          key: build-{{ .Branch }}-{{ checksum "Cargo.toml" }}
+          key: build-1.26.0jessie-{{ .Branch }}-{{ checksum "Cargo.toml" }}
       - run:
           name: Build
           command: |
@@ -26,7 +26,7 @@ jobs:
           name: Test
           command: cargo test -- --nocapture
       - save_cache:
-          key: build-{{ .Branch }}-{{ checksum "Cargo.toml" }}
+          key: build-1.26.0jessie-{{ .Branch }}-{{ checksum "Cargo.toml" }}
           paths:
             - "~/.cargo"
             - "./target"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 0%
+ignore:
+  - "benches/.*"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,8 @@
 coverage:
   status:
+    patch:
+      default:
+        target: 0%
     project:
       default:
         target: 0%


### PR DESCRIPTION
This PR adds a coverage run to the Circle config added in #16 , using [tarpaulin](https://github.com/xd009642/tarpaulin) to collect coverage information and [Codecov](https://codecov.io) to show output. For a sense of how the coverage reports look, see [this branch's coverage info](https://codecov.io/gh/mapbox/fuzzy-phrase/tree/918731653e30579780c2d1035b808d450af2abd7).

The coverage run ends up meaning we run the tests twice; we could do it just once, but tarpaulin seems to insist on rebuilding everything every time rather than benefiting from cache (I assume it needs to rebuild it with some special flags to collect coverage info?), so this way if we're going to fail we fail fast, but just end up waiting a little longer on success, which feels like a good tradeoff to me.

Other odds and ends:
* tarpaulin is a cargo extension and can either be built locally, or you can download a prebuilt one. The latter seems to be much faster than the former so I did that, but the prebuilt one is dynamically linked against `libssl1.0.0` whereas the default Circle rust image I was using before (based on Debian Stretch) had `libssl1.0.2`. They also have Debian Jessie Rust images, so I switched to that for now, which gets us the older libssl. In the future we could think about building locally every time, building our own Docker image with tarpaulin already installed, or hosting our own prebuilt binary linked against a newer libssl. Again, this feels fine for now.
* the tarpaulin installer expects cargo to be in a different place from where Circle puts it by default, so there's some hacky symlinking to make it happy
* I've configured codecov for now to have coverage targets both for the project and patch of `0%`, which means it will always pass. In the immediate term I wanted to have coverage reports available for people's information value (to make sure they're testing what they want to test) without having test coverage be an obnoxious barrier while a lot of code is still moving around. Once things stabilize we should set a coverage target as a group, bump these targets to something real, and work on hitting them together.