### PR TITLE
Fuzzy keep distance

### DIFF
--- a/src/fuzzy/map.rs
+++ b/src/fuzzy/map.rs
@@ -15,15 +15,22 @@ use rmps::{Deserializer, Serializer};
 use strsim::damerau_levenshtein;
 #[cfg(test)] extern crate reqwest;
 
-static BIG_NUMBER: usize = 1 << 30;
+static BIG_NUMBER: u64 = 1 << 30;
 
 pub struct FuzzyMap {
-    id_list: Vec<Vec<usize>>,
+    id_list: Vec<Vec<u32>>,
     fst: raw::Fst
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct SerializableIdList(Vec<Vec<usize>>);
+pub struct SerializableIdList(Vec<Vec<u32>>);
+
+#[derive(PartialEq, Eq, Debug)]
+pub struct FuzzyMapLookupResult {
+    pub word: String,
+    pub id: u32,
+    pub edit_distance: u8,
+}
 
 impl FuzzyMap {
     #[cfg(feature = "mmap")]
@@ -67,9 +74,9 @@ impl FuzzyMap {
     pub fn get<K: AsRef<[u8]>>(&self, key: K) -> Option<u64> {
         self.fst.get(key).map(|output| output.value())
     }
-    //get rid of ids
-    pub fn lookup<'a, F>(&self, query: &str, edit_distance: u64, lookup_fn: F) -> Result<Vec<(String, u64)>, Box<Error>> where F: Fn(usize) -> &'a str {
-        let mut matches = Vec::<usize>::new();
+
+    pub fn lookup<'a, F>(&self, query: &str, edit_distance: u8, lookup_fn: F) -> Result<Vec<FuzzyMapLookupResult>, Box<Error>> where F: Fn(u32) -> &'a str {
+        let mut matches = Vec::<u32>::new();
 
         let variants = super::get_variants(&query, edit_distance);
 
@@ -77,12 +84,12 @@ impl FuzzyMap {
         for i in iter::once(query).chain(variants.iter().map(|a| a.as_str())) {
             match self.fst.get(&i) {
                 Some (idx) => {
-                    let uidx = idx.value() as usize;
+                    let uidx = idx.value();
                     if uidx < BIG_NUMBER {
-                        matches.push(uidx);
+                        matches.push(uidx as u32);
                     } else {
-                       for x in &(self.id_list)[uidx - BIG_NUMBER] {
-                            matches.push(*x);
+                       for x in &(self.id_list)[(uidx - BIG_NUMBER) as usize] {
+                            matches.push(*x as u32);
                         }
                     }
                 }
@@ -94,57 +101,63 @@ impl FuzzyMap {
 
         Ok(matches
             .into_iter().dedup()
-            .map(|id| (lookup_fn(id), id as u64))
-            .filter(|(word, _id)| damerau_levenshtein(query, word) <= edit_distance as usize)
-            .map(|(word, id)| (word.to_owned(), id))
-            .collect::<Vec<(String, u64)>>()
+            .filter_map(|id| {
+                let word = lookup_fn(id);
+                let distance = damerau_levenshtein(query, word);
+                if distance <= edit_distance as usize {
+                    Some(FuzzyMapLookupResult { word: word.to_owned(), id: id as u32, edit_distance: distance as u8 })
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<FuzzyMapLookupResult>>()
         )
     }
 }
 
 pub struct FuzzyMapBuilder {
-    id_builder: Vec<Vec<usize>>,
+    id_builder: Vec<Vec<u32>>,
     builder: raw::Builder<BufWriter<File>>,
     file_path: PathBuf,
-    word_variants: Vec<(String, usize)>,
-    edit_distance: u64,
+    word_variants: Vec<(String, u32)>,
+    edit_distance: u8,
 }
 
 impl FuzzyMapBuilder {
-    pub fn new<P: AsRef<Path>>(path: P, edit_distance: u64) -> Result<Self, Box<Error>> {
+    pub fn new<P: AsRef<Path>>(path: P, edit_distance: u8) -> Result<Self, Box<Error>> {
         let file_start = path.as_ref().to_owned();
         let fst_wtr = BufWriter::new(fs::File::create(file_start.with_extension(".fst"))?);
 
         Ok(FuzzyMapBuilder {
             builder: raw::Builder::new_type(fst_wtr, 0)?,
-            id_builder: Vec::<Vec<usize>>::new(),
+            id_builder: Vec::<Vec<u32>>::new(),
             file_path: file_start,
-            word_variants: Vec::<(String, usize)>::new(),
+            word_variants: Vec::<(String, u32)>::new(),
             edit_distance: edit_distance,
         })
     }
 
-    pub fn build_from_iter<'a, T, P: AsRef<Path>>(path: P, words: T, edit_distance: u64) -> Result<(), Box<Error>> where T: Iterator<Item=&'a str> {
+    pub fn build_from_iter<'a, T, P: AsRef<Path>>(path: P, words: T, edit_distance: u8) -> Result<(), Box<Error>> where T: Iterator<Item=&'a str> {
         let mut fuzzy_map_builder = FuzzyMapBuilder::new(path, edit_distance)?;
 
         for (i, word) in words.enumerate() {
-            fuzzy_map_builder.insert(word, i as u64);
+            fuzzy_map_builder.insert(word, i as u32);
         }
         fuzzy_map_builder.finish()?;
         Ok(())
     }
 
-    pub fn insert(&mut self, key: &str, id: u64) -> () {
-        self.word_variants.push((key.to_owned(), id as usize));
+    pub fn insert(&mut self, key: &str, id: u32) -> () {
+        self.word_variants.push((key.to_owned(), id));
         let variants = super::get_variants(&key, self.edit_distance);
         for j in variants.into_iter() {
-            self.word_variants.push((j, id as usize));
+            self.word_variants.push((j, id));
         }
     }
 
     pub fn extend_iter<'a, T, I>(&mut self, iter: I) -> Result<(), FstError> where T: AsRef<[u8]>, I: IntoIterator<Item=&'a str> {
         for (i, word) in iter.into_iter().enumerate() {
-            self.insert(word, i as u64);
+            self.insert(word, i as u32);
         }
         Ok(())
     }
@@ -155,12 +168,12 @@ impl FuzzyMapBuilder {
         for (key, group) in &(&self.word_variants).iter().dedup().group_by(|t| &t.0) {
             let opts = group.collect::<Vec<_>>();
             let id = if opts.len() == 1 {
-                opts[0].1
+                opts[0].1 as u64
             } else {
                 self.id_builder.push((&opts).iter().map(|t| t.1).collect::<Vec<_>>());
-                self.id_builder.len() - 1 + BIG_NUMBER
+                (self.id_builder.len() - 1) as u64 + BIG_NUMBER
             };
-            self.builder.insert(key, id as u64)?;
+            self.builder.insert(key, id)?;
         }
         let mf_wtr = BufWriter::new(fs::File::create(self.file_path.with_extension(".msg"))?);
         SerializableIdList(self.id_builder).serialize(&mut Serializer::new(mf_wtr)).unwrap();
@@ -247,7 +260,12 @@ mod tests {
         .text().expect("tried to decode the data");
         let mut words = data.trim().split("\n").collect::<Vec<&str>>();
         words.sort();
-        let no_return = Vec::<(String, u64)>::new();
+
+        let expect = |word: &'static str, query: &'static str| {
+            FuzzyMapLookupResult { word: word.to_owned(), id: words.binary_search(&word).unwrap() as u32, edit_distance: damerau_levenshtein(&word, &query) as u8 }
+        };
+
+        let no_return = Vec::<FuzzyMapLookupResult>::new();
 
         let dir = tempfile::tempdir().unwrap();
         let file_start = dir.path().join("fuzzy");
@@ -255,46 +273,51 @@ mod tests {
 
         let map = unsafe { FuzzyMap::from_path(&file_start).unwrap() };
         let query1 = "alazan";
-        let matches = map.lookup(&query1, 1, |id| &words[id]);
-        assert_eq!(matches.unwrap(), [("albazan".to_owned(), words.binary_search(&"albazan").unwrap() as u64)]);
+        let matches = map.lookup(&query1, 1, |id| &words[id as usize]);
+        assert_eq!(matches.unwrap(), [expect("albazan", query1)]);
 
         //exact lookup, the original word in the data is - "agߪkaधaݤcݤkaqag"
         let query2 = "agߪkaधaݤcݤkaqag";
-        let matches = map.lookup(&query2, 1, |id| &words[id]);
-        assert_eq!(matches.unwrap(), [("agߪkaधaݤcݤkaqag".to_owned(), words.binary_search(&"agߪkaधaݤcݤkaqag").unwrap() as u64)]);
+        let matches = map.lookup(&query2, 1, |id| &words[id as usize]);
+        assert_eq!(matches.unwrap(), [expect("agߪkaधaݤcݤkaqag", query2)]);
 
         //not exact lookup, the original word is - "blockquoteanciently", d=1
         let query3 = "blockquteanciently";
-        let matches = map.lookup(&query3, 1, |id| &words[id]);
-        assert_eq!(matches.unwrap(), [("blockquoteanciently".to_owned(), words.binary_search(&"blockquoteanciently").unwrap() as u64)]);
+        let matches = map.lookup(&query3, 1, |id| &words[id as usize]);
+        assert_eq!(matches.unwrap(), [expect("blockquoteanciently", query3)]);
 
         //not exact lookup, d=1, more more than one suggestion because of two similiar words in the data
         //albana and albazan
         let query4 = "albaza";
-        let matches = map.lookup(&query4, 1, |id| &words[id]);
-        assert_eq!(matches.unwrap(), [("albana".to_owned(), words.binary_search(&"albana").unwrap() as u64), ("albazan".to_owned(), words.binary_search(&"albazan").unwrap() as u64)]);
+        let matches = map.lookup(&query4, 1, |id| &words[id as usize]);
+        assert_eq!(matches.unwrap(), [expect("albana", query4), expect("albazan", query4)]);
 
         //garbage input
         let query4 = "🤔";
-        let matches = map.lookup(&query4, 1, |id| &words[id]);
+        let matches = map.lookup(&query4, 1, |id| &words[id as usize]);
         assert_eq!(matches.unwrap(), no_return);
 
         let query5 = "";
-        let matches = map.lookup(&query5, 1, |id| &words[id]);
+        let matches = map.lookup(&query5, 1, |id| &words[id as usize]);
         assert_eq!(matches.unwrap(), no_return);
     }
-    #[test]
 
+    #[test]
     fn lookup_test_cases_d_2() {
         extern crate tempfile;
         let words = vec!["100", "main", "street"];
+
+        let expect = |word: &'static str, query: &'static str| {
+            FuzzyMapLookupResult { word: word.to_owned(), id: words.binary_search(&word).unwrap() as u32, edit_distance: damerau_levenshtein(&word, &query) as u8 }
+        };
+
         let dir = tempfile::tempdir().unwrap();
         let file_start = dir.path().join("fuzzy");
         FuzzyMapBuilder::build_from_iter(&file_start, words.iter().cloned(), 2).unwrap();
 
         let map = unsafe { FuzzyMap::from_path(&file_start).unwrap() };
         let query1 = "sret";
-        let matches = map.lookup(&query1, 2, |id| &words[id]);
-        assert_eq!(matches.unwrap(), [("street".to_owned(), words.binary_search(&"street").unwrap() as u64)])
+        let matches = map.lookup(&query1, 2, |id| &words[id as usize]);
+        assert_eq!(matches.unwrap(), [expect("street", query1)])
     }
 }

--- a/src/fuzzy/mod.rs
+++ b/src/fuzzy/mod.rs
@@ -6,13 +6,13 @@ pub use self::map::FuzzyMapBuilder;
 #[cfg(test)] extern crate reqwest;
 
 #[inline(always)]
-fn get_variants<'a>(word: &str, edit_distance: u64) -> HashSet<String> {
+fn get_variants<'a>(word: &str, edit_distance: u8) -> HashSet<String> {
     let mut variants: HashSet<String> = HashSet::new();
     get_variants_recursive(word, 1, edit_distance, &mut variants);
     variants
 }
 
-fn get_variants_recursive<'a>(word: &str, edit_distance: u64, max_distance: u64, delete_variants: &'a mut HashSet<String>) -> () {
+fn get_variants_recursive<'a>(word: &str, edit_distance: u8, max_distance: u8, delete_variants: &'a mut HashSet<String>) -> () {
     let mut iter = word.char_indices().peekable();
 
     while let Some((pos, _char)) = iter.next() {


### PR DESCRIPTION
Several changes here, but nothing major or structural:
* change all word IDs to `u32` and all edit distances to `u8`. Only use usize to look stuff up in arrays, where it's required
* Make lookup return a struct instead of a tuple so the results are easier to work with, and have it include the edit distance, which the glue code needs
* Clean up after my own laziness and do the flagging of multi-IDs in a more grown-up way (no more `BIG_NUMBER`; use bit math instead)
* Clean up after the last round of PRs that introduced some ugliness: the `map`-then-`filter`-then `map` thing in lookup becomes a single `filter_map`, and factor out the thing that determines the expected results from lookup into an `expect` closure

going to merge into my working branch but cc @aarthykc for review to merge into master