### PR TITLE
[phrase] bench comparison

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ optional = true
 reqwest = "0.8.5"
 criterion = "0.2"
 tempfile = "3.0.2"
+rand = "0.5.0"
 
 [features]
 default = ["mmap"]

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -4,6 +4,7 @@ extern crate fuzzy_phrase;
 extern crate fst;
 extern crate reqwest;
 extern crate itertools;
+extern crate rand;
 
 use criterion::Criterion;
 

--- a/benches/phrase.rs
+++ b/benches/phrase.rs
@@ -2,6 +2,7 @@ use std::fs::File;
 use std::io::{BufRead, BufReader, SeekFrom};
 use std::collections::{BTreeSet, BTreeMap};
 use std::rc::Rc;
+use std::env;
 use rand::{thread_rng, seq, Rng};
 use criterion::{Criterion, Fun, Bencher};
 use fuzzy_phrase::{PhraseSet, PhraseSetBuilder};
@@ -72,8 +73,14 @@ pub fn benchmark(c: &mut Criterion) {
         phrases: Vec<Vec<u32>>,
         phrase_set: PhraseSet
     };
-
-    let (word_to_id, phrases, phrase_set) = build_phrase_graph("./benches/data/phrase_test.txt");
+    let data_loc = match env::var("PHRASE_BENCH") {
+        Ok(f) => {
+            println!("file loc is {}", f);
+            f
+        },
+        Err(..) => String::from("./benches/data/phrase_test.txt"),
+    };
+    let (word_to_id, phrases, phrase_set) = build_phrase_graph(&data_loc);
 
     // move the prebuilt data into a reference-counted struct
     let shared_data = Rc::new(BenchData { word_to_id, phrases, phrase_set });

--- a/benches/phrase.rs
+++ b/benches/phrase.rs
@@ -148,6 +148,27 @@ pub fn benchmark(c: &mut Criterion) {
         });
     }));
 
+    // data is shadowed here for ease of copying and pasting, but this is a new clone
+    // (again, same data, new reference, because it's an Rc)
+    let data = shared_data.clone();
+    to_bench.push(Fun::new("range_fst_range", move |b: &mut Bencher, _i| {
+        let mut rng = thread_rng();
+
+        b.iter(|| {
+            let word_ids = rng.choose(&data.phrases).unwrap();
+            let fullword_ids = &word_ids[..word_ids.len()];
+            let last_id = &word_ids[word_ids.len()-1];
+            let last_id_min = 0.max(last_id - 50);
+            let last_id_max = last_id + 50;
+            let mut query_words = fullword_ids.iter()
+                .map(|w| QueryWord::Full{ id: *w, edit_distance: 0})
+                .collect::<Vec<QueryWord>>();
+            query_words.push(QueryWord::Prefix{ id_range: (last_id_min, last_id_max) });
+            let query_phrase = QueryPhrase::new(&query_words).unwrap();
+            let _result = data.phrase_set.range(query_phrase).unwrap();
+        });
+    }));
+
     // run the accumulated list of benchmarks
     c.bench_functions("phrase", to_bench, ());
 }

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -8,10 +8,6 @@ set -eu -o pipefail
 
 export TMP=/tmp/fuzzy-phrase-bench
 export S3_DIR=s3://mapbox/playground/boblannon/fuzzy-phrase/bench
-export COMBINED_CSV="${TMP}/gb.csv"
-export COMBINED_GEOJSON="${TMP}/gb.geojson"
-export CSV_INSIDE="$(dirname $0)/mapbox-places-address/lib/csv-inside.js"
-
 
 function download() {
     type=$1

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -9,6 +9,16 @@ set -eu -o pipefail
 export TMP=/tmp/fuzzy-phrase-bench
 export S3_DIR=s3://mapbox/playground/boblannon/fuzzy-phrase/bench
 
+
+#################################################################################
+# Download
+#
+# This downloads test data from s3 and extracts it.  Example:
+#
+#     ./scripts/bench.sh download phrase us en latn
+#
+# ...would download the benchmark data for `phrase/` benchmarks for United
+# States (us), in English (en), in Latin script (latn).
 function download() {
     type=$1
     country=$2
@@ -25,6 +35,16 @@ function download() {
     exit 0
 }
 
+#################################################################################
+# Run
+#
+# This runs benchmarks on a certain type and on certain data. The data is
+# presumed to exist in the local $TMP. Example:
+#
+#     ./scripts/bench.sh run phrase us en latn
+#
+# ...would run `cargo bench` using the benchmark data for `phrase/` benchmarks
+# for United States (us), in English (en), in Latin script (latn).
 function run() {
     type=$1
     country=$2

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+#################################################################################
+# GLOBALS                                                                       #
+#################################################################################
+
+export TMP=/tmp/fuzzy-phrase-bench
+export S3_DIR=s3://mapbox/playground/boblannon/fuzzy-phrase/bench
+export COMBINED_CSV="${TMP}/gb.csv"
+export COMBINED_GEOJSON="${TMP}/gb.geojson"
+export CSV_INSIDE="$(dirname $0)/mapbox-places-address/lib/csv-inside.js"
+
+
+function download() {
+    type=$1
+    country=$2
+    language=$3
+    script=$4
+    fname="${country}_${language}_${script}.txt.gz"
+    FROM="${S3_DIR}/${type}/${fname}"
+    TO="${TMP}/${type}/${fname}"
+    mkdir -p "${TMP}/${type}"
+    echo "Downloading ${FROM}"
+    aws s3 cp $FROM $TO
+    echo "Extracting ${TO}"
+    gunzip $TO
+    exit 0
+}
+
+function run() {
+    type=$1
+    country=$2
+    language=$3
+    script=$4
+    fname="${country}_${language}_${script}.txt"
+    echo "running"
+    env PHRASE_BENCH="${TMP}/${type}/${fname}" cargo bench "${type}"
+    exit 0
+}
+
+# remove tmp dir
+function clean() {
+    if [[ -d $TMP ]]; then
+        echo "ok - Are you sure you wish to wipe ${TMP}? (Y/n)"
+        read WRITE_IP
+
+        if [[ $WRITE_IP != "n" ]]; then
+            rm -rf $TMP
+        fi
+    fi
+}
+
+VERB=$1
+
+case $VERB in
+    download)   download $2 $3 $4 $5;;
+    run)        run $2 $3 $4 $5;;
+    clean)      clean;;
+    *)          echo "not ok - invalid command" && exit 3;;
+esac

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -52,7 +52,7 @@ function run() {
     script=$4
     fname="${country}_${language}_${script}.txt"
     echo "running"
-    env PHRASE_BENCH="${TMP}/${type}/${fname}" cargo bench "${type}"
+    env PHRASE_BENCH="${TMP}/${type}/${fname}" cargo bench -v "${type}"
     exit 0
 }
 

--- a/src/phrase/query.rs
+++ b/src/phrase/query.rs
@@ -93,16 +93,17 @@ impl<'a> QueryPhrase<'a> {
 
     /// Generate a key from the ids of the full words in this phrase
     pub fn full_word_key(&self) -> Vec<u8> {
-        let mut word_ids: Vec<u32> = vec![];
+        let mut full_word_key: Vec<u8> = vec![];
         for word in self.words {
             match word {
                 QueryWord::Full{ ref id, .. } => {
-                    word_ids.push(*id);
+                    let three_bytes = util::three_byte_encode(*id);
+                    full_word_key.extend(three_bytes);
                 },
                 _ => (),
             }
         }
-        util::word_ids_to_key(&word_ids)
+        full_word_key
     }
 
     /// Generate a key from the prefix range


### PR DESCRIPTION
This PR adds some capabilities to running phrase benchmarks on real-world data. It also will add a few new benchmarks to compare the custom solution to a straightforward use of `range` and `StartsWith` functions available from the `fst` library.

New things:

- a script for downloading phrase benchmark data and running phrase benchmarks (can be extended to support others)
- now possible to specify the source for phrase benchmark data using the env variable `PHRASE_BENCH`