### PR TITLE
using a fixed sample to bench PhraseSet

### DIFF
--- a/benches/data/phrase_test_sample.txt
+++ b/benches/data/phrase_test_sample.txt
@@ -1,0 +1,10 @@
+34 Wooded Glenn Ct
+70 Kennel Ct
+15 Slow Creek Dr
+19# Southchase Blvd
+57 Redman Dr
+42# Congaree Rd
+82 Coquina Ct
+49 Sandown Ln
+40 Dumont Dr
+61 Trammell Mountain Trl

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -25,9 +25,19 @@ function download() {
     language=$3
     script=$4
     fname="${country}_${language}_${script}.txt.gz"
+    sample_fname="${country}_${language}_${script}_sample.txt.gz"
+
+    mkdir -p "${TMP}/${type}"
+
     FROM="${S3_DIR}/${type}/${fname}"
     TO="${TMP}/${type}/${fname}"
-    mkdir -p "${TMP}/${type}"
+    echo "Downloading ${FROM}"
+    aws s3 cp $FROM $TO
+    echo "Extracting ${TO}"
+    gunzip $TO
+
+    FROM="${S3_DIR}/${type}/${sample_fname}"
+    TO="${TMP}/${type}/${sample_fname}"
     echo "Downloading ${FROM}"
     aws s3 cp $FROM $TO
     echo "Extracting ${TO}"
@@ -50,9 +60,10 @@ function run() {
     country=$2
     language=$3
     script=$4
-    fname="${country}_${language}_${script}.txt"
+    # this will be used to create filenames ${fbasename}.txt and ${fbasename}_sample.txt
+    fbasename="${country}_${language}_${script}"
     echo "running"
-    env PHRASE_BENCH="${TMP}/${type}/${fname}" cargo bench -v "${type}"
+    env PHRASE_BENCH="${TMP}/${type}/${fbasename}" cargo bench -v "${type}"
     exit 0
 }
 


### PR DESCRIPTION
This change uses a pre-prepared random sample fixture to do benchmarking on `PhraseSet`, in hopes of avoiding the kind of unexpected jiggle seen in #25 comparisons.