### PR TITLE
Pin tarpaulin to 0.5.6 for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
       - run:
           name: Coverage
           command: |
-            bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
+            curl -sL https://github.com/xd009642/tarpaulin/releases/download/0.5.6/cargo-tarpaulin-0.5.6-travis.tar.gz | tar xvz -C $HOME/.cargo/bin
             cargo tarpaulin \
               --ciserver circle-ci \
               --verbose --out Xml


### PR DESCRIPTION
Taurpalin, which we use for coverage, just released [0.6.0](https://www.reddit.com/r/rust/comments/8qcrqb/tarpaulin_060_is_released_and_a_look_at_whats/). Up until now we automatically used the latest version on CI, but our builds started failing with 0.6.0. It looks like this new release introduces some new fanciness for doing accurate coverage of macro-generated code, which both introduces some new dependencies that are tricky to compile, and some brittleness with macro-heavy crates (some of which we depend on either directly or indirectly, like `serde_derive` and `failure`).

I made some attempts in [this branch](https://github.com/mapbox/fuzzy-phrase/tree/fix-tarpaulin) to fix the problems, by building tarpaulin ourselves rather than using a prebuilt one (which fixed some version conflict stuff), using a dev branch of their Rust parser (which fixed some, but not all, of the macro brittleness), and using a dev branch of tarpaulin itself (which fixed more, but still broke on `failure`).

[This taurpalin bug](https://github.com/xd009642/tarpaulin/issues/99) still seems to be a blocker, so for now, I'm going to propose pinning to the previous (and still working) version, 0.5.6, and revisiting once some of the kinks are worked out in the new version.

cc @ingalls for your reference, since we had talked about tarpaulin for coverage in Hecate