### PR TITLE
Switch our docker image to rust 1.26.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ machine:
 jobs:
   build:
     docker:
-      - image: circleci/rust:1.26.0-jessie
+      - image: circleci/rust:1.26.2-jessie
     steps:
       - setup-docker-engine
       - checkout
@@ -15,7 +15,7 @@ jobs:
           name: Symlink Cargo
           command: ln -s /usr/local/cargo ~/.cargo
       - restore_cache:
-          key: build-1.26.0jessie-{{ .Branch }}-{{ checksum "Cargo.toml" }}
+          key: build-1.26.2jessie-{{ .Branch }}-{{ checksum "Cargo.toml" }}
       - run:
           name: Build
           command: |
@@ -26,7 +26,7 @@ jobs:
           name: Test
           command: cargo test -- --nocapture
       - save_cache:
-          key: build-1.26.0jessie-{{ .Branch }}-{{ checksum "Cargo.toml" }}
+          key: build-1.26.2jessie-{{ .Branch }}-{{ checksum "Cargo.toml" }}
           paths:
             - "~/.cargo"
             - "./target"


### PR DESCRIPTION
Circle is broken, because apparently the Circle-provided Docker image we were using to get a Rust compiler (1.26.0-jessie) has up and vanished. Not sure why that would be. If this happens again, we should consider building our own (and maybe bake Tarpaulin onto it as a bonus).

Going to yolo-merge since all the circle things are blocked.