### PR TITLE
[WIP] Tests for fuzzy_match_multi and fuzzy_match_windows

### DIFF
--- a/src/glue/fuzz_tests.rs
+++ b/src/glue/fuzz_tests.rs
@@ -71,3 +71,45 @@ fn glue_fuzztest_match_prefix() {
         }
     }
 }
+
+#[test]
+#[ignore]
+fn fuzzy_match_windowed_multi_equivalent_test() {
+    let cities: Vec<&str> = include_str!("../../benches/data/phrase_test_cities.txt").trim().split("\n").collect();
+    let states: Vec<&str> = include_str!("../../benches/data/phrase_test_states.txt").trim().split("\n").collect();
+    let mut rng = rand::thread_rng();
+    let mut augmented_phrases: Vec<String> = Vec::with_capacity(1000);
+    for _i in 0..1000 {
+        let phrase = rng.choose(&PHRASES).unwrap();
+        let damaged = get_damaged_phrase(phrase, |w| SET.can_fuzzy_match(w));
+        let zip: u32 = rng.gen_range(10000, 99999);
+        let augmented = format!(
+            "{addr} {city} {state} {zip}",
+            addr = damaged,
+            city = rng.choose(&cities).unwrap(),
+            state = rng.choose(&states).unwrap(),
+            zip = zip
+        );
+        augmented_phrases.push(augmented);
+    }
+
+    for phrase in augmented_phrases.iter() {
+        let tokens: Vec<_> = phrase.split(" ").collect();
+        let mut variants: Vec<(Vec<&str>, bool)> = Vec::new();
+        let windowed_match_result = SET.fuzzy_match_windows(tokens.as_slice(), 1, 1, false).unwrap();
+        for start in 0..tokens.len() {
+            for end in start..tokens.len() {
+                variants.push((tokens[start..(end + 1)].to_vec(), false));
+            }
+        }
+        let windowed_match_multi_result = SET.fuzzy_match_multi(variants.as_slice(), 1, 1).unwrap();
+        //check if windowed match and multi windowed match give the same results
+        assert!(windowed_match_result.iter().any(|x| {
+            windowed_match_multi_result.iter().any(|y| {
+                y.iter().any(|z| {
+                    x == z
+                })
+            })
+        }));
+    }
+}

--- a/src/glue/fuzz_tests.rs
+++ b/src/glue/fuzz_tests.rs
@@ -134,3 +134,73 @@ fn glue_fuzztest_windowed_multi_equivalent() {
         assert_eq!(windowed_match_result, emulated_windowed_match_result);
     }
 }
+
+#[test]
+#[ignore]
+fn glue_fuzztest_windowed_multi_equivalent_prefix() {
+    let cities: Vec<&str> = include_str!("../../benches/data/phrase_test_cities.txt").trim().split("\n").collect();
+    let states: Vec<&str> = include_str!("../../benches/data/phrase_test_states.txt").trim().split("\n").collect();
+    let mut rng = rand::thread_rng();
+    let mut augmented_phrases: Vec<String> = Vec::with_capacity(1000);
+    for _i in 0..100 {
+        let phrase = rng.choose(&PHRASES).unwrap();
+        let damaged = get_damaged_phrase(phrase, |w| SET.can_fuzzy_match(w));
+        let zip: u32 = rng.gen_range(10000, 99999);
+
+        // make a string with the components in random order
+        let mut augmented_vec = vec![
+            damaged,
+            rng.choose(&cities).unwrap().to_string(),
+            rng.choose(&states).unwrap().to_string(),
+            zip.to_string()
+        ];
+        rng.shuffle(augmented_vec.as_mut_slice());
+        let augmented = augmented_vec.join(" ");
+        augmented_phrases.push(random_trunc(&augmented));
+    }
+
+    for phrase in augmented_phrases.iter() {
+        let tokens: Vec<_> = phrase.split(" ").collect();
+        let mut variants: Vec<(Vec<&str>, bool)> = Vec::new();
+        let mut variant_starts: Vec<usize> = Vec::new();
+        let mut variant_eip: Vec<bool> = Vec::new();
+        for start in 0..tokens.len() {
+            for end in start..tokens.len() {
+                let ends_in_prefix = end + 1 == tokens.len();
+                variants.push((tokens[start..(end + 1)].to_vec(), ends_in_prefix));
+                variant_starts.push(start);
+                variant_eip.push(ends_in_prefix);
+            }
+        }
+        let individual_match_result = variants.iter().map(|v| if v.1 {
+            SET.fuzzy_match_prefix(v.0.as_slice(), 1, 1).unwrap()
+        } else {
+            SET.fuzzy_match(v.0.as_slice(), 1, 1).unwrap()
+        }).collect::<Vec<_>>();
+        let multi_match_result = SET.fuzzy_match_multi(variants.as_slice(), 1, 1).unwrap();
+
+        // check if the multi match results and the one-by-one match results are identical
+        assert_eq!(individual_match_result, multi_match_result);
+
+        // to make sure the windowed match and multi windowed match give the same results, we need
+        // to reformat the multi-match results to look like windowed match results based on the
+        // start position and length of each variant
+        let mut windowed_match_result = SET.fuzzy_match_windows(tokens.as_slice(), 1, 1, true).unwrap();
+        let mut emulated_windowed_match_result: Vec<FuzzyWindowResult> = Vec::new();
+        for i in 0..multi_match_result.len() {
+            for result in &multi_match_result[i] {
+                emulated_windowed_match_result.push(FuzzyWindowResult {
+                    phrase: result.phrase.clone(),
+                    edit_distance: result.edit_distance,
+                    start_position: variant_starts[i],
+                    ends_in_prefix: variant_eip[i]
+                });
+            }
+        }
+
+        windowed_match_result.sort();
+        emulated_windowed_match_result.sort();
+
+        assert_eq!(windowed_match_result, emulated_windowed_match_result);
+    }
+}

--- a/src/glue/mod.rs
+++ b/src/glue/mod.rs
@@ -782,8 +782,9 @@ mod tests {
         static ref FUZZY_DATA: String = {
             let test_data = ensure_data("phrase", "us", "en", "latn", true);
             let mut file = fs::File::open(test_data).unwrap();
-            let mut data = String::new();
-            file.read_to_string(&mut data).unwrap();
+            let mut file_data = String::new();
+            file.read_to_string(&mut file_data).unwrap();
+            let data: String = file_data[..20].to_string();
             data
         };
         static ref PHRASES: Vec<&'static str> = {
@@ -791,6 +792,7 @@ mod tests {
         };
         static ref FUZZY_SET: FuzzyPhraseSet = {
             let mut builder = FuzzyPhraseSetBuilder::new(&TEMP_DIR.path()).unwrap();
+
             for phrase in PHRASES.iter() {
                 builder.insert_str(phrase).unwrap();
             }

--- a/src/glue/mod.rs
+++ b/src/glue/mod.rs
@@ -168,16 +168,16 @@ pub struct FuzzyPhraseSet {
     script_regex: regex::Regex,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
 pub struct FuzzyMatchResult {
-    pub phrase: Vec<String>,
     pub edit_distance: u8,
+    pub phrase: Vec<String>,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
 pub struct FuzzyWindowResult {
-    pub phrase: Vec<String>,
     pub edit_distance: u8,
+    pub phrase: Vec<String>,
     pub start_position: usize,
     pub ends_in_prefix: bool,
 }

--- a/src/glue/mod.rs
+++ b/src/glue/mod.rs
@@ -184,6 +184,7 @@ pub struct FuzzyWindowResult {
 
 impl<'a, 'b> PartialEq<FuzzyMatchResult> for FuzzyWindowResult {
     fn eq(&self, other: &FuzzyMatchResult) -> bool {
+        self.edit_distance == other.edit_distance;
         self.phrase == other.phrase
     }
 }

--- a/src/glue/mod.rs
+++ b/src/glue/mod.rs
@@ -973,8 +973,8 @@ mod tests {
 
         for damaged_phrase in damaged_phrases.iter() {
             let damaged_phrase_windows: Vec<&str> = damaged_phrase.split(' ').collect();
-            let windowed_match_result = FUZZY_SET.fuzzy_match_windows(&damaged_phrase_windows, 1, 1, true).unwrap();
-            let windowed_match_multi_result = FUZZY_SET.fuzzy_match_multi(&[(&damaged_phrase_windows, true)], 1, 1).unwrap();
+            let windowed_match_result = FUZZY_SET.fuzzy_match_windows(&damaged_phrase_windows, 1, 1, false).unwrap();
+            let windowed_match_multi_result = FUZZY_SET.fuzzy_match_multi(&[(&damaged_phrase_windows, false)], 1, 1).unwrap();
             assert_eq!(windowed_match_result[0], windowed_match_multi_result[0][0]);
         }
     }

--- a/src/glue/mod.rs
+++ b/src/glue/mod.rs
@@ -567,9 +567,9 @@ impl FuzzyPhraseSet {
                 )?;
                 for (phrase_p, sq_ends_in_prefix) in &phrase_matches {
                     results.push(FuzzyWindowResult {
-                        phrase: phrase_p.iter().enumerate().map(|(i, qw)| match qw {
+                        phrase: phrase_p.iter().enumerate().map(|(j, qw)| match qw {
                             QueryWord::Full { id, .. } => self.word_list[*id as usize].clone(),
-                            QueryWord::Prefix { .. } => phrase[chunk.start_position + i].as_ref().to_owned(),
+                            QueryWord::Prefix { .. } => phrase[chunk.start_position + i + j].as_ref().to_owned(),
                         }).collect::<Vec<String>>(),
                         edit_distance: phrase_p.iter().map(|qw| match qw {
                             QueryWord::Full { edit_distance, .. } => *edit_distance,


### PR DESCRIPTION
Branched off `window-weld`, this PR will add the following: 

- lazy_static that constructs FuzzyPhraseSet, which I did using `ensure-data` in `test_utils`
- Partial_eq for `FuzzyMatchResult` and `FuzzyWindowResult` to check if the phrases un the result are equivalent
- test to check if `fuzzy_match_windows` and `fuzzy_match_multi` give the same result when a "damaged" (phrase that contains a typo) is passed.

cc @boblannon 