### PR TITLE
Fix bench panic

### DIFF
--- a/benches/fuzzy.rs
+++ b/benches/fuzzy.rs
@@ -24,7 +24,10 @@ pub fn benchmark(c: &mut Criterion) {
             println!("file loc is {}", f);
             f
         },
-        Err(..) => String::from("/tmp/fuzzy-map-bench/fuzzy/"),
+        Err(..) => {
+            println!("skipping fuzzy benchmarks");
+            return
+        },
     };
     let exact_data_loc = format!("{}.txt", data_basename);
     let f = File::open(exact_data_loc).expect("tried to open_file");


### PR DESCRIPTION
The code in each benchmark file outside of the closures gets run every time you run `cargo bench`, regardless of filters. For the `fuzzy` bench code in particular, it tries to check some env vars and open the files they point to, even if users are running other benchmarks and not running the `fuzzy` ones (e.g., with a name filter). At present, even in this circumstance, if the env vars aren't set or the files don't exist, the bencher panics.

This PR instead skips loading the files and attempting to run the benchmarks if the env var isn't set. We should probably eventually instead ship some default data like we do for phrase, or automatically download it within Rust, as we do in glue. Suggesting this PR as a quick unblocker in the meantime, though, as it's not a pressing priority.

cc @aarthykc 