### PR TITLE
Window weld unit test

### DIFF
--- a/src/phrase/mod.rs
+++ b/src/phrase/mod.rs
@@ -93,7 +93,7 @@ impl PhraseSet {
             let (key, edit_distance) = match word {
                 QueryWord::Full { key, edit_distance, .. } => (*key, *edit_distance),
                 _ => return Err(PhraseSetError::new(
-                    "The query submitted has a QueryWord::Prefix. Set::contains only accepts QueryWord:Full"
+                    "The query submitted has a QueryWord::Prefix. This function only accepts QueryWord:Full"
                 )),
             };
             if edit_distance > budget_remaining {
@@ -298,7 +298,7 @@ impl PhraseSet {
                 QueryWord::Prefix { key_range, .. } => {
                     if !ends_in_prefix {
                         return Err(PhraseSetError::new(
-                            "The query submitted has a QueryWord::Prefix. Set::contains only accepts QueryWord:Full"
+                            "The query submitted has a QueryWord::Prefix. This function only accepts QueryWord:Full"
                         ))
                     }
                     if self.matches_prefix_range(

--- a/src/phrase/mod.rs
+++ b/src/phrase/mod.rs
@@ -296,6 +296,11 @@ impl PhraseSet {
                     }
                 },
                 QueryWord::Prefix { key_range, .. } => {
+                    if !ends_in_prefix {
+                        return Err(PhraseSetError::new(
+                            "The query submitted has a QueryWord::Prefix. Set::contains only accepts QueryWord:Full"
+                        ))
+                    }
                     if self.matches_prefix_range(
                         node.addr(),
                         *key_range

--- a/src/phrase/tests.rs
+++ b/src/phrase/tests.rs
@@ -569,7 +569,7 @@ fn sample_contains_windows() {
 }
 
 #[test]
-fn sample_contains_windows_as_prefixes() {
+fn sample_full_contains_windows_as_prefixes() {
     // just test everything
     let max_phrase_dist = 2;
     for phrase in PHRASES.iter() {
@@ -609,4 +609,38 @@ fn sample_contains_windows_as_prefixes() {
     }
 }
 
+
+#[test]
+fn sample_prefix_contains_windows_as_prefixes() {
+    // just test everything
+    let max_phrase_dist = 2;
+    for phrase in PHRASES.iter() {
+        let query_phrase = get_full(phrase);
+        let word_possibilities = get_prefix_variants(phrase);
+        let results;
+        results = SET.match_combinations_as_prefixes(
+            &word_possibilities,
+            max_phrase_dist
+        ).unwrap();
+        assert!(results.len() > 0);
+        if !(results.iter().any(|r| *r == query_phrase)) {
+            println!("phrase:{:?}\nresult: {:?}", query_phrase, results);
+        }
+        assert!(results.iter().any(|r| {
+            r.iter().enumerate().all(|(i, qw)| match qw {
+                QueryWord::Full { .. } => *qw == query_phrase[i],
+                QueryWord::Prefix { id_range, .. } => {
+                    match query_phrase[i] {
+                        QueryWord::Full { id, .. } => {
+                            id <= id_range.1 && id >= id_range.0
+                        },
+                        QueryWord::Prefix { .. } => {
+                            panic!("should be no prefixes");
+                        }
+                    }
+                }
+            })
+        }));
+    }
+}
 

--- a/src/phrase/tests.rs
+++ b/src/phrase/tests.rs
@@ -586,7 +586,6 @@ fn sample_match_combinations_as_windows_all_full() {
         query_phrase.pop();
         word_possibilities.pop();
 
-
         let results = SET.match_combinations_as_windows(
             &word_possibilities,
             max_phrase_dist,
@@ -605,8 +604,8 @@ fn sample_match_combinations_as_windows_all_prefix() {
     for phrase in PHRASES.iter() {
         let query_phrase = get_prefix(phrase);
         let word_possibilities = get_prefix_variants(phrase);
-        let results;
-        results = SET.match_combinations_as_windows(
+
+        let results = SET.match_combinations_as_windows(
             &word_possibilities,
             max_phrase_dist,
             true
@@ -614,4 +613,101 @@ fn sample_match_combinations_as_windows_all_prefix() {
         assert!(results.len() > 0);
         assert!(results.iter().any(|r| (&r.0, r.1) == (&query_phrase, true)));
     }
+}
+
+#[test]
+fn sample_prefix_contains_windows_overlap() {
+    let word_possibilities = get_prefix_variants("84# Gleason Hollow Rd");
+    let results = SET.match_combinations_as_windows(
+        &word_possibilities,
+        1,
+        true
+    ).unwrap();
+
+    // this should match two different results, one of which is a prefix of the other, since we
+    // augmented the data with some prefix examples
+    assert_eq!(
+        results,
+        vec![
+            // this one doesn't end in the prefix
+            (get_full("84# Gleason Hollow"), false),
+            // but this one does
+            (get_prefix("84# Gleason Hollow Rd"), true),
+        ]
+    );
+}
+
+#[test]
+fn sample_prefix_contains_windows_substring() {
+    // this works
+    let word_possibilities = get_prefix_variants("59 Old Ne");
+    let results = SET.match_combinations_as_windows(
+        &word_possibilities,
+        1,
+        true
+    ).unwrap();
+    assert_eq!(results, vec![(get_prefix("59 Old Ne"), true)]);
+
+    // but this will fail because we can't window-recurse with eip=false and a PrefixWord
+    let results = SET.match_combinations_as_windows(
+        &word_possibilities,
+        1,
+        false
+    );
+    assert!(results.is_err());
+
+    // so let's try with just full words...
+    // except this also doesn't work when searched non-prefix
+    let word_possibilities = get_full_variants("59 Old New");
+    let results = SET.match_combinations_as_windows(
+        &word_possibilities,
+        1,
+        false
+    ).unwrap();
+    assert_eq!(results, vec![]);
+
+    // and it doesn't work with crap added to the end of it
+    let word_possibilities = get_prefix_variants("59 Old New Gleason");
+    let results = SET.match_combinations_as_windows(
+        &word_possibilities,
+        1,
+        true
+    ).unwrap();
+    assert_eq!(results, vec![]);
+
+    // or to the beginning -- we'd need to have a different start position
+    let word_possibilities = get_prefix_variants("Gleason 59 Old New");
+    let results = SET.match_combinations_as_windows(
+        &word_possibilities,
+        1,
+        true
+    ).unwrap();
+    assert_eq!(results, vec![]);
+
+    // on the other hand, we *should* be able to find a whole string with other stuff after it
+    let word_possibilities = get_prefix_variants("59 Old New Milford Rd Gleason");
+    let results = SET.match_combinations_as_windows(
+        &word_possibilities,
+        1,
+        true
+    ).unwrap();
+    assert_eq!(results, vec![(get_full("59 Old New Milford Rd"), false)]);
+
+    // and should also work with no prefixes
+    let word_possibilities = get_full_variants("59 Old New Milford Rd Gleason");
+    let results = SET.match_combinations_as_windows(
+        &word_possibilities,
+        1,
+        false
+    ).unwrap();
+    assert_eq!(results, vec![(get_full("59 Old New Milford Rd"), false)]);
+
+    // on the other hand, it still shouldn't work with stuff at the beginning
+    let word_possibilities = get_prefix_variants("Gleason 59 Old New Milford Rd");
+    let results = SET.match_combinations_as_windows(
+        &word_possibilities,
+        1,
+        true
+    ).unwrap();
+    assert_eq!(results, vec![]);
 }


### PR DESCRIPTION
This adds unit tests for the `match_combinations_as_windows` and `match_combinations_as_prefixes` functions.