### PR TITLE
On-disk format stability fixes/changes

### DIFF
--- a/src/fuzzy/map.rs
+++ b/src/fuzzy/map.rs
@@ -50,8 +50,8 @@ impl FuzzyMap {
     #[cfg(feature = "mmap")]
     pub unsafe fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, FstError> {
         let file_start = path.as_ref();
-        let fst = raw::Fst::from_path(file_start.with_extension(".fst")).unwrap();
-        let mf_reader = BufReader::new(fs::File::open(file_start.with_extension(".msg"))?);
+        let fst = raw::Fst::from_path(file_start.with_extension("fst")).unwrap();
+        let mf_reader = BufReader::new(fs::File::open(file_start.with_extension("msg"))?);
         let id_list: SerializableIdList = Deserialize::deserialize(&mut Deserializer::new(mf_reader)).unwrap();
         Ok(FuzzyMap { id_list: id_list.0, fst: fst })
     }
@@ -191,7 +191,7 @@ pub struct FuzzyMapBuilder {
 impl FuzzyMapBuilder {
     pub fn new<P: AsRef<Path>>(path: P, edit_distance: u8) -> Result<Self, Box<Error>> {
         let file_start = path.as_ref().to_owned();
-        let fst_wtr = BufWriter::new(fs::File::create(file_start.with_extension(".fst"))?);
+        let fst_wtr = BufWriter::new(fs::File::create(file_start.with_extension("fst"))?);
 
         Ok(FuzzyMapBuilder {
             builder: raw::Builder::new_type(fst_wtr, 0)?,
@@ -240,7 +240,7 @@ impl FuzzyMapBuilder {
             };
             self.builder.insert(key, id)?;
         }
-        let mf_wtr = BufWriter::new(fs::File::create(self.file_path.with_extension(".msg"))?);
+        let mf_wtr = BufWriter::new(fs::File::create(self.file_path.with_extension("msg"))?);
         SerializableIdList(self.id_builder).serialize(&mut Serializer::new(mf_wtr)).unwrap();
         self.builder.finish()
     }

--- a/src/glue/mod.rs
+++ b/src/glue/mod.rs
@@ -3,13 +3,13 @@ use std::path::{Path, PathBuf};
 use std::error::Error;
 use std::io::{Error as IoError, ErrorKind as IoErrorKind, BufReader, BufWriter};
 use std::fs;
-use std::cmp::min;
 
 use serde_json;
 use fst::Streamer;
 
 use ::prefix::{PrefixSet, PrefixSetBuilder};
 use ::phrase::{PhraseSet, PhraseSetBuilder};
+use ::phrase::util::PhraseSetError;
 use ::phrase::query::{QueryPhrase, QueryWord};
 use ::fuzzy::{FuzzyMap, FuzzyMapBuilder};
 use regex;
@@ -32,6 +32,7 @@ struct FuzzyPhraseSetMetadata {
     index_type: String,
     format_version: u32,
     fuzzy_enabled_scripts: Vec<String>,
+    max_edit_distance: u8,
 }
 
 impl Default for FuzzyPhraseSetMetadata {
@@ -40,6 +41,7 @@ impl Default for FuzzyPhraseSetMetadata {
             index_type: "fuzzy_phrase_set".to_string(),
             format_version: 1,
             fuzzy_enabled_scripts: vec!["Latin".to_string(), "Greek".to_string(), "Cyrillic".to_string()],
+            max_edit_distance: 1,
         }
     }
 }
@@ -90,6 +92,9 @@ impl FuzzyPhraseSetBuilder {
     }
 
     pub fn finish(mut self) -> Result<(), Box<Error>> {
+        // in the future we could make some of this setable from the outside
+        let metadata = FuzzyPhraseSetMetadata::default();
+
         // we can go from name -> tmpid
         // we need to go from tmpid -> id
         // so build a mapping that does that
@@ -98,9 +103,10 @@ impl FuzzyPhraseSetBuilder {
         let prefix_writer = BufWriter::new(fs::File::create(self.directory.join(Path::new("prefix.fst")))?);
         let mut prefix_set_builder = PrefixSetBuilder::new(prefix_writer)?;
 
-        let mut fuzzy_map_builder = FuzzyMapBuilder::new(self.directory.join(Path::new("fuzzy")), 1)?;
-
-        let metadata = FuzzyPhraseSetMetadata::default();
+        let mut fuzzy_map_builder = FuzzyMapBuilder::new(
+            self.directory.join(Path::new("fuzzy")),
+            metadata.max_edit_distance
+        )?;
 
         // this is a regex set to decide whether to index somehing for fuzzy matching
         let allowed_scripts = &metadata.fuzzy_enabled_scripts.iter().map(
@@ -164,6 +170,7 @@ pub struct FuzzyPhraseSet {
     fuzzy_map: FuzzyMap,
     word_list: Vec<String>,
     script_regex: regex::Regex,
+    max_edit_distance: u8,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -197,6 +204,8 @@ impl FuzzyPhraseSet {
             &unicode_ranges::get_pattern_for_scripts(&allowed_scripts),
         ).unwrap();
 
+        let max_edit_distance = metadata.max_edit_distance;
+
         let prefix_path = directory.join(Path::new("prefix.fst"));
         if !prefix_path.exists() {
             return Err(Box::new(IoError::new(IoErrorKind::NotFound, "Prefix FST does not exist")));
@@ -225,7 +234,9 @@ impl FuzzyPhraseSet {
         let fuzzy_path = directory.join(Path::new("fuzzy"));
         let fuzzy_map = unsafe { FuzzyMap::from_path(&fuzzy_path) }?;
 
-        Ok(FuzzyPhraseSet { prefix_set, phrase_set, fuzzy_map, word_list, script_regex })
+        Ok(FuzzyPhraseSet {
+            prefix_set, phrase_set, fuzzy_map, word_list, script_regex, max_edit_distance
+        })
     }
 
     pub fn can_fuzzy_match(&self, word: &str) -> bool {
@@ -289,10 +300,15 @@ impl FuzzyPhraseSet {
 
         let mut word_possibilities: Vec<Vec<QueryWord>> = Vec::with_capacity(phrase.len());
 
-        // later we should preserve the max edit distance we can support with the structure we have built
-        // and either throw an error or silently constrain to that
-        // but for now, we're hard-coded to one at build time, so hard coded to one and read time
-        let edit_distance = min(max_word_dist, 1);
+        let edit_distance = if max_word_dist > self.max_edit_distance {
+            return Err(Box::new(PhraseSetError::new(format!(
+                "The maximum configured edit distance for this index is {}; {} requested",
+                self.max_edit_distance,
+                max_word_dist
+            ).as_str())));
+        } else {
+            max_word_dist
+        };
 
         for word in phrase {
             let word = word.as_ref();
@@ -350,10 +366,15 @@ impl FuzzyPhraseSet {
             return Ok(Vec::new());
         }
 
-        // later we should preserve the max edit distance we can support with the structure we have built
-        // and either throw an error or silently constrain to that
-        // but for now, we're hard-coded to one at build time, so hard coded to one and read time
-        let edit_distance = min(max_word_dist, 1);
+        let edit_distance = if max_word_dist > self.max_edit_distance {
+            return Err(Box::new(PhraseSetError::new(format!(
+                "The maximum configured edit distance for this index is {}; {} requested",
+                self.max_edit_distance,
+                max_word_dist
+            ).as_str())));
+        } else {
+            max_word_dist
+        };
 
         // all words but the last one: fuzzy-lookup if eligible, or exact-match if not,
         // and return nothing if those fail
@@ -446,6 +467,15 @@ mod tests {
     #[test]
     fn glue_build() -> () {
         lazy_static::initialize(&SET);
+
+        let mut contents: Vec<_> = fs::read_dir(&DIR.path()).unwrap().map(|entry| {
+            entry.unwrap().file_name().into_string().unwrap()
+        }).collect();
+        contents.sort();
+        assert_eq!(
+            contents,
+            vec!["fuzzy.fst", "fuzzy.msg", "metadata.json", "phrase.fst", "prefix.fst"]
+        );
     }
 
     #[test]
@@ -531,6 +561,8 @@ mod tests {
                 FuzzyMatchResult { phrase: vec!["100".to_string(), "main".to_string(), "street".to_string()], edit_distance: 2 },
             ]
         );
+
+        assert!(SET.fuzzy_match(&["100", "man", "stret"], 2, 2).is_err());
     }
 
     #[test]
@@ -548,6 +580,8 @@ mod tests {
                 FuzzyMatchResult { phrase: vec!["100".to_string(), "main".to_string(), "str".to_string()], edit_distance: 1 },
             ]
         );
+
+        assert!(SET.fuzzy_match_prefix(&["100", "man"], 2, 1).is_err());
     }
 }
 


### PR DESCRIPTION
This PR contains a couple of changes I wanted to sneak under the wire to the on-disk representation of the data structures we build, since once we start to roll out indexes that will eventually be bound for production, these will be harder to change (will require a format version bump and global rebuild).

Specifically:
- [x] Fix a typo that caused the fuzzy-map-related files to have two dots (`fuzzy..fst` instead of `fuzzy.fst`, etc.) -- this is cosmetic, but may as well fix it now. Also added a test that confirms that the files are named as we expect them to be.
- [x] Bake the max edit distance we use to build the fuzzy map into our metadata file. This will allow us, in the future, to make this configurable and potentially build some indexes with different max edit distances without necessitating a rebuild of any indexes we build now. **Note:** I'm using this property internally now that it's there, but not actually exposing it to be externally configurable in this PR. That part feels premature to me at the moment since I think we're pretty set on just doing 1, and we can always do it later without affecting the disk format once this PR lands.
- [x] Add actual failures to be triggered if someone requests a higher-than-supported edit distance, rather than silently swallowing them. For now this reuses/abuses the `PhraseSetError` error type rather than defining a new one, because our strategy for how to handle errors library-wide is still a little up in the air and meant to be resolved in #42 . Again, getting this right isn't important to the disk format side of the equation.

Anything else anyone wants to tweak before we commit?