### PR TITLE
Fast path for d=0 fuzzy matches

### DIFF
--- a/benches/glue.rs
+++ b/benches/glue.rs
@@ -177,6 +177,53 @@ pub fn benchmark(c: &mut Criterion) {
         });
     }));
 
+    // these next few will construct some phrases that have fake additional cities/states/zips
+    // to test windowing and multi-lookup tests on
+    let data = shared_data.clone();
+    let mut rng = rand::thread_rng();
+    let mut augmented_exact_phrases: Vec<String> = Vec::with_capacity(1000);
+    for _i in 0..1000 {
+        let phrase = rng.choose(&data.phrases).unwrap();
+        let zip: u32 = rng.gen_range(10000, 99999);
+        let augmented = format!(
+            "{addr} {city} {state} {zip}",
+            addr = phrase,
+            city = rng.choose(&cities).unwrap(),
+            state = rng.choose(&states).unwrap(),
+            zip = zip
+        );
+        augmented_exact_phrases.push(augmented);
+    }
+    let augmented_exact_phrases = Rc::new(augmented_exact_phrases);
+
+    let data = shared_data.clone();
+    let sample = augmented_exact_phrases.clone();
+    to_bench.push(Fun::new("fuzzy_match_complex_multi_exact", move |b: &mut Bencher, _i| {
+        let mut cycle = sample.iter().cycle();
+
+        b.iter(|| {
+            let tokens: Vec<_> = cycle.next().unwrap().split(" ").collect();
+            let mut variants: Vec<(Vec<&str>, bool)> = Vec::new();
+            for start in 0..tokens.len() {
+                for end in start..tokens.len() {
+                    variants.push((tokens[start..(end + 1)].to_vec(), false));
+                }
+            }
+            data.set.fuzzy_match_multi(variants.as_slice(), 0, 0).unwrap();
+        });
+    }));
+
+    let data = shared_data.clone();
+    let sample = augmented_exact_phrases.clone();
+    to_bench.push(Fun::new("fuzzy_match_complex_windows_exact", move |b: &mut Bencher, _i| {
+        let mut cycle = sample.iter().cycle();
+
+        b.iter(|| {
+            let tokens: Vec<_> = cycle.next().unwrap().split(" ").collect();
+            data.set.fuzzy_match_windows(tokens.as_slice(), 0, 0, false).unwrap();
+        });
+    }));
+
     // run the accumulated list of benchmarks
     c.bench_functions("glue", to_bench, ());
 }

--- a/src/glue/mod.rs
+++ b/src/glue/mod.rs
@@ -313,7 +313,7 @@ impl FuzzyPhraseSet {
 
     #[inline(always)]
     fn get_nonterminal_word_possibilities(&self, word: &str, edit_distance: u8) -> Result<Option<Vec<QueryWord>>, Box<Error>> {
-        if self.can_fuzzy_match(word) {
+        if edit_distance > 0 && self.can_fuzzy_match(word) {
             let fuzzy_results = self.fuzzy_map.lookup(&word, edit_distance, |id| &self.word_list[id as usize])?;
             if fuzzy_results.len() == 0 {
                 Ok(None)
@@ -343,7 +343,7 @@ impl FuzzyPhraseSet {
             false
         };
 
-        if self.can_fuzzy_match(word) {
+        if edit_distance > 0 && self.can_fuzzy_match(word) {
             let last_fuzzy_results = self.fuzzy_map.lookup(word, edit_distance, |id| &self.word_list[id as usize])?;
             for result in last_fuzzy_results {
                 if found_prefix && result.edit_distance == 0 {


### PR DESCRIPTION
This is a slight optimization for fuzzy_match, fuzzy_match_windows, fuzzy_match_multi, etc., to avoid doing fuzzy lookups for d=0 requests, along with associated benchmarks to measure the improvement. This change makes these queries about three times faster (though to be fair, they were already very fast compared to d=1).