### PR TITLE
[dnm] Stop using mmap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,6 @@ rmp-serde = "0.13.7"
 lazy_static = "1.0"
 regex = "1.0"
 
-[dependencies.memmap]
-version = "0.6.0"
-optional = true
-
 [dev-dependencies]
 reqwest = "0.8.5"
 criterion = "0.2"
@@ -25,10 +21,6 @@ tempfile = "3.0.2"
 rand = "0.5.0"
 strsim = "0.7.0"
 test_utils = { path = "test_utils" }
-
-[features]
-default = ["mmap"]
-mmap = ["memmap"]
 
 [[bench]]
 name = "benchmarks"

--- a/src/glue/mod.rs
+++ b/src/glue/mod.rs
@@ -228,7 +228,7 @@ impl FuzzyPhraseSet {
         if !prefix_path.exists() {
             return Err(Box::new(IoError::new(IoErrorKind::NotFound, "Prefix FST does not exist")));
         }
-        let prefix_set = unsafe { PrefixSet::from_path(&prefix_path) }?;
+        let prefix_set = PrefixSet::from_path(&prefix_path)?;
 
         // the fuzzy graph needs to be able to go from ID to actual word
         // one idea was to look this up from the prefix graph, which can do backwards lookups
@@ -247,10 +247,10 @@ impl FuzzyPhraseSet {
         if !phrase_path.exists() {
             return Err(Box::new(IoError::new(IoErrorKind::NotFound, "Phrase FST does not exist")));
         }
-        let phrase_set = unsafe { PhraseSet::from_path(&phrase_path) }?;
+        let phrase_set = PhraseSet::from_path(&phrase_path)?;
 
         let fuzzy_path = directory.join(Path::new("fuzzy"));
-        let fuzzy_map = unsafe { FuzzyMap::from_path(&fuzzy_path) }?;
+        let fuzzy_map = FuzzyMap::from_path(&fuzzy_path)?;
 
         Ok(FuzzyPhraseSet {
             prefix_set, phrase_set, fuzzy_map, word_list, script_regex, max_edit_distance

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 extern crate fst;
 extern crate itertools;
-extern crate memmap;
 extern crate byteorder;
 extern crate regex;
 

--- a/src/phrase/mod.rs
+++ b/src/phrase/mod.rs
@@ -2,8 +2,9 @@ pub mod util;
 pub mod query;
 
 use std::io;
-#[cfg(feature = "mmap")]
 use std::path::Path;
+use std::io::prelude::*;
+use std::fs::File;
 
 use fst;
 use fst::{IntoStreamer, Set, SetBuilder, Streamer};
@@ -383,9 +384,13 @@ impl PhraseSet {
         Set::from_bytes(bytes).map(PhraseSet)
     }
 
-    #[cfg(feature = "mmap")]
-    pub unsafe fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, fst::Error> {
-        Set::from_path(path).map(PhraseSet)
+    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, fst::Error> {
+        let mut buffer: Vec<u8> = Vec::new();
+        let mut file = io::BufReader::new(File::open(path)?);
+        file.read_to_end(&mut buffer)?;
+        buffer.shrink_to_fit();
+
+        PhraseSet::from_bytes(buffer)
     }
 
 }

--- a/src/phrase/tests.rs
+++ b/src/phrase/tests.rs
@@ -58,7 +58,7 @@ fn insert_phrases_file() {
     build.insert(&[561_528u32, 1u32, 61_528_u32]).unwrap();
     build.finish().unwrap();
 
-    let phrase_set = unsafe { PhraseSet::from_path("/tmp/phrase-set.fst") }.unwrap();
+    let phrase_set = PhraseSet::from_path("/tmp/phrase-set.fst").unwrap();
 
     let mut keys = vec![];
     let mut stream = phrase_set.into_stream();


### PR DESCRIPTION
This is an experimental branch that disables memory-mapped IO in favor of just loading all FSTs up-front. Upside: removes all unsafe code, and might lead to better production performance without warmup. Downside: more memory usage, and benches seem to tank a bit on OSX (though not on Linux, for some reason?)

If this ends up being useful, we may want to consider, rather than just changing it, allowing both and making it runtime-configurable, like the underlying fuzzy library does.