### PR TITLE
Refactor prefix lookup functions to support terminal token replacement

### DIFF
--- a/benches/prefix.rs
+++ b/benches/prefix.rs
@@ -38,7 +38,7 @@ pub fn benchmark(c: &mut Criterion) {
         let mut cycle = data.words.iter().cycle();
         // the closure based to b.iter is the thing that will actually be timed; everything before
         // that is untimed per-benchmark setup
-        b.iter(|| data.prefix_set.contains(cycle.next().unwrap()));
+        b.iter(|| data.prefix_set.lookup(cycle.next().unwrap()).found_final());
     }));
 
     // data is shadowed here for ease of copying and pasting, but this is a new clone
@@ -46,19 +46,19 @@ pub fn benchmark(c: &mut Criterion) {
     let data = shared_data.clone();
     to_bench.push(Fun::new("exact_contains_prefix", move |b: &mut Bencher, _i| {
         let mut cycle = data.words.iter().cycle();
-        b.iter(|| data.prefix_set.contains_prefix(cycle.next().unwrap()));
+        b.iter(|| data.prefix_set.lookup(cycle.next().unwrap()).found());
     }));
 
     let data = shared_data.clone();
     to_bench.push(Fun::new("exact_get", move |b: &mut Bencher, _i| {
         let mut cycle = data.words.iter().cycle();
-        b.iter(|| data.prefix_set.get(cycle.next().unwrap()));
+        b.iter(|| data.prefix_set.lookup(cycle.next().unwrap()).id());
     }));
 
     let data = shared_data.clone();
     to_bench.push(Fun::new("exact_get_prefix_range", move |b: &mut Bencher, _i| {
         let mut cycle = data.words.iter().cycle();
-        b.iter(|| data.prefix_set.get_prefix_range(cycle.next().unwrap()));
+        b.iter(|| data.prefix_set.lookup(cycle.next().unwrap()).range());
     }));
 
     let data = shared_data.clone();
@@ -71,7 +71,7 @@ pub fn benchmark(c: &mut Criterion) {
             w.chars().take(char_count - 1).collect()
         }).collect::<Vec<String>>();
         let mut cycle = prefixes.iter().cycle();
-        b.iter(|| data.prefix_set.contains_prefix(cycle.next().unwrap()));
+        b.iter(|| data.prefix_set.lookup(cycle.next().unwrap()).found());
     }));
 
     let data = shared_data.clone();
@@ -81,7 +81,7 @@ pub fn benchmark(c: &mut Criterion) {
             w.chars().take(if char_count < 2 { char_count } else { 2 }).collect()
         }).dedup().collect::<Vec<String>>();
         let mut cycle = prefixes.iter().cycle();
-        b.iter(|| data.prefix_set.get_prefix_range(cycle.next().unwrap()));
+        b.iter(|| data.prefix_set.lookup(cycle.next().unwrap()).range());
     }));
 
     let data = shared_data.clone();

--- a/src/glue/mod.rs
+++ b/src/glue/mod.rs
@@ -293,8 +293,8 @@ impl FuzzyPhraseSet {
         // and then look up that ID sequence in the phrase graph
         let mut id_phrase: Vec<QueryWord> = Vec::with_capacity(phrase.len());
         for word in phrase {
-            match self.prefix_set.get(word.as_ref()) {
-                Some(word_id) => { id_phrase.push(QueryWord::new_full(word_id as u32, 0)) },
+            match self.prefix_set.lookup(word.as_ref()).id() {
+                Some(word_id) => { id_phrase.push(QueryWord::new_full(word_id.value() as u32, 0)) },
                 None => { return Ok(false) }
             }
         }
@@ -317,12 +317,12 @@ impl FuzzyPhraseSet {
         if phrase.len() > 0 {
             let last_idx = phrase.len() - 1;
             for word in phrase[..last_idx].iter() {
-                match self.prefix_set.get(word.as_ref()) {
-                    Some(word_id) => { id_phrase.push(QueryWord::new_full(word_id as u32, 0)) },
+                match self.prefix_set.lookup(word.as_ref()).id() {
+                    Some(word_id) => { id_phrase.push(QueryWord::new_full(word_id.value() as u32, 0)) },
                     None => { return Ok(false) }
                 }
             }
-            match self.prefix_set.get_prefix_range(phrase[last_idx].as_ref()) {
+            match self.prefix_set.lookup(phrase[last_idx].as_ref()).range() {
                 Some((word_id_start, word_id_end)) => { id_phrase.push(QueryWord::new_prefix((word_id_start.value() as u32, word_id_end.value() as u32))) },
                 None => { return Ok(false) }
             }
@@ -354,8 +354,8 @@ impl FuzzyPhraseSet {
                 Ok(Some(variants))
             }
         } else {
-            match self.prefix_set.get(&word) {
-                Some(word_id) => { Ok(Some(vec![QueryWord::new_full(word_id as u32, 0)])) },
+            match self.prefix_set.lookup(&word).id() {
+                Some(word_id) => { Ok(Some(vec![QueryWord::new_full(word_id.value() as u32, 0)])) },
                 None => { Ok(None) }
             }
         }
@@ -365,7 +365,7 @@ impl FuzzyPhraseSet {
     fn get_terminal_word_possibilities(&self, word: &str, edit_distance: u8) -> Result<Option<Vec<QueryWord>>, Box<Error>> {
         // last word: try both prefix and, if eligible, fuzzy lookup, and return nothing if both fail
         let mut last_variants: Vec<QueryWord> = Vec::new();
-        let found_prefix = if let Some((word_id_start, word_id_end)) = self.prefix_set.get_prefix_range(word) {
+        let found_prefix = if let Some((word_id_start, word_id_end)) = self.prefix_set.lookup(word).range() {
             last_variants.push(QueryWord::new_prefix((word_id_start.value() as u32, word_id_end.value() as u32)));
             true
         } else {

--- a/src/prefix/boilerplate.rs
+++ b/src/prefix/boilerplate.rs
@@ -31,10 +31,6 @@ impl PrefixSet {
         PrefixSet::from_bytes(builder.into_inner()?)
     }
 
-    pub fn contains<K: AsRef<[u8]>>(&self, key: K) -> bool {
-        self.0.contains_key(key)
-    }
-
     pub fn stream(&self) -> Stream {
         Stream::new(self.0.stream())
     }
@@ -45,11 +41,6 @@ impl PrefixSet {
 
     pub fn as_fst(&self) -> &raw::Fst {
         &self.0
-    }
-
-    // this one is from Map
-    pub fn get<K: AsRef<[u8]>>(&self, key: K) -> Option<u64> {
-        self.0.get(key).map(|output| output.value())
     }
 }
 

--- a/src/prefix/mod.rs
+++ b/src/prefix/mod.rs
@@ -7,25 +7,13 @@ pub use self::boilerplate::PrefixSetBuilder;
 #[cfg(test)] mod tests;
 
 impl PrefixSet {
-    pub fn contains_prefix<B: AsRef<[u8]>>(&self, key: B) -> bool {
-        let fst = &self.as_fst();
-        let mut node = fst.root();
-        for &b in key.as_ref() {
-            node = match node.find_input(b) {
-                None => return false,
-                Some(i) => fst.node(node.transition_addr(i)),
-            }
-        }
-        true
-    }
-
-    pub fn get_prefix_range<B: AsRef<[u8]>>(&self, key: B) -> Option<(raw::Output, raw::Output)> {
+    pub fn lookup<B: AsRef<[u8]>>(&self, key: B) -> PrefixSetLookupResult {
         let fst = &self.as_fst();
         let mut node = fst.root();
         let mut out = raw::Output::zero();
         for &b in key.as_ref() {
             node = match node.find_input(b) {
-                None => return None,
+                None => return PrefixSetLookupResult::NotFound,
                 Some(i) => {
                     let t = node.transition(i);
                     out = out.cat(t.out);
@@ -33,14 +21,7 @@ impl PrefixSet {
                 }
             }
         }
-        let start = out.cat(node.final_output());
-
-        while node.len() != 0 {
-            let t = node.transition(node.len() - 1);
-            out = out.cat(t.out);
-            node = fst.node(t.addr);
-        }
-        Some((start, out.cat(node.final_output())))
+        PrefixSetLookupResult::Found { fst, node, output_so_far: out }
     }
 
     pub fn get_by_id(&self, id: raw::Output) -> Option<Vec<u8>> {
@@ -81,6 +62,65 @@ impl PrefixSet {
                 Some(n) => node = n,
                 None => return None,
             }
+        }
+    }
+}
+
+pub enum PrefixSetLookupResult<'a> {
+    NotFound,
+    Found { fst: &'a raw::Fst, node: raw::Node<'a>, output_so_far: raw::Output }
+}
+
+impl<'a> PrefixSetLookupResult<'a> {
+    pub fn found(&self) -> bool {
+        match *self {
+            PrefixSetLookupResult::NotFound => false,
+            PrefixSetLookupResult::Found {..} => true
+        }
+    }
+
+    pub fn found_final(&self) -> bool {
+        match *self {
+            PrefixSetLookupResult::NotFound => false,
+            PrefixSetLookupResult::Found { node, .. } => node.is_final()
+        }
+    }
+
+    pub fn id(&self) -> Option<raw::Output> {
+        match *self {
+            PrefixSetLookupResult::NotFound => None,
+            PrefixSetLookupResult::Found { node, output_so_far, .. } => {
+                if node.is_final() {
+                    Some(output_so_far.cat(node.final_output()))
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    pub fn range(&self) -> Option<(raw::Output, raw::Output)> {
+        match *self {
+            PrefixSetLookupResult::NotFound => None,
+            PrefixSetLookupResult::Found { fst, node, output_so_far } => {
+                let mut node: raw::Node = node.to_owned();
+                let mut out: raw::Output = output_so_far.to_owned();
+                let start = out.cat(node.final_output());
+
+                while node.len() != 0 {
+                    let t = node.transition(node.len() - 1);
+                    out = out.cat(t.out);
+                    node = fst.node(t.addr);
+                }
+                Some((start, out.cat(node.final_output())))
+            }
+        }
+    }
+
+    pub fn has_continuations(&self) -> bool {
+        match *self {
+            PrefixSetLookupResult::NotFound => false,
+            PrefixSetLookupResult::Found { node, .. } => node.len() > 0
         }
     }
 }


### PR DESCRIPTION
Checklist item 3 in #54 requires being able to distinguish between three states for prefix matching: a final phrase token that's just a word prefix (in which case we shouldn't try to token-replace it), a final token that's just a complete word (in which case, we if that word ought to be token-replaced, we should replace it), or one that's both (in which case we should emit both the replaced full word and the unreplaced prefix as candidates during phrase graph traversal). The functions we had in place before didn't supply the necessary level of detail about the matches they found, so this PR replaces the various lookup functions (get, contains, contains_prefix, get_range, etc.) with a single function that returns an enum with methods to interrogate multiple facts about the match.

# Summary of changes
- [x] replace the various prefix lookup functions with a single lookup function
- [x] get tests passing

# Next actions
- [x] update benchmarks to use new functions, and compare performance