### PR TITLE
Introduce word-boundary params and return values

### DIFF
--- a/benches/glue.rs
+++ b/benches/glue.rs
@@ -77,7 +77,7 @@ pub fn benchmark(c: &mut Criterion) {
         let mut cycle = damaged_phrases.iter().cycle();
         // the closure based to b.iter is the thing that will actually be timed; everything before
         // that is untimed per-benchmark setup
-        b.iter(|| data.set.fuzzy_match_str(cycle.next().unwrap(), 1, 1));
+        b.iter(|| data.set.fuzzy_match_str(cycle.next().unwrap(), 1, 1, EndingType::NonPrefix));
     }));
 
     // data is shadowed here for ease of copying and pasting, but this is a new clone
@@ -96,7 +96,7 @@ pub fn benchmark(c: &mut Criterion) {
         let mut cycle = damaged_phrases.iter().cycle();
         // the closure based to b.iter is the thing that will actually be timed; everything before
         // that is untimed per-benchmark setup
-        b.iter(|| data.set.fuzzy_match_prefix_str(cycle.next().unwrap(), 1, 1));
+        b.iter(|| data.set.fuzzy_match_str(cycle.next().unwrap(), 1, 1, EndingType::AnyPrefix));
     }));
 
     let data = shared_data.clone();
@@ -113,7 +113,7 @@ pub fn benchmark(c: &mut Criterion) {
         let mut cycle = damaged_phrases.iter().cycle();
         // the closure based to b.iter is the thing that will actually be timed; everything before
         // that is untimed per-benchmark setup
-        b.iter(|| data.set_with_replacements.fuzzy_match_prefix_str(cycle.next().unwrap(), 1, 1));
+        b.iter(|| data.set_with_replacements.fuzzy_match_str(cycle.next().unwrap(), 1, 1, EndingType::AnyPrefix));
     }));
 
     let data = shared_data.clone();
@@ -121,7 +121,7 @@ pub fn benchmark(c: &mut Criterion) {
         let lt_data = get_data("phrase", "lt", "lt", "latn", true);
         let mut cycle = lt_data.iter().cycle();
 
-        b.iter(|| data.set.fuzzy_match_str(cycle.next().unwrap(), 1, 1));
+        b.iter(|| data.set.fuzzy_match_str(cycle.next().unwrap(), 1, 1, EndingType::NonPrefix));
     }));
 
     let data = shared_data.clone();
@@ -129,7 +129,7 @@ pub fn benchmark(c: &mut Criterion) {
         let ua_data = get_data("phrase", "ua", "uk", "cyrl", true);
         let mut cycle = ua_data.iter().cycle();
 
-        b.iter(|| data.set.fuzzy_match_str(cycle.next().unwrap(), 1, 1));
+        b.iter(|| data.set.fuzzy_match_str(cycle.next().unwrap(), 1, 1, EndingType::NonPrefix));
     }));
 
     let data = shared_data.clone();
@@ -141,7 +141,7 @@ pub fn benchmark(c: &mut Criterion) {
 
         let mut cycle = garbage_phrases.iter().cycle();
 
-        b.iter(|| data.set.fuzzy_match_str(cycle.next().unwrap(), 1, 1));
+        b.iter(|| data.set.fuzzy_match_str(cycle.next().unwrap(), 1, 1, EndingType::NonPrefix));
     }));
 
     let data = shared_data.clone();
@@ -153,7 +153,7 @@ pub fn benchmark(c: &mut Criterion) {
 
         let mut cycle = garbage_phrases.iter().cycle();
 
-        b.iter(|| data.set.fuzzy_match_str(cycle.next().unwrap(), 1, 1));
+        b.iter(|| data.set.fuzzy_match_str(cycle.next().unwrap(), 1, 1, EndingType::NonPrefix));
     }));
 
     // these next few will construct some phrases that have fake additional cities/states/zips
@@ -187,7 +187,7 @@ pub fn benchmark(c: &mut Criterion) {
             let tokens: Vec<_> = cycle.next().unwrap().split(" ").collect();
             for start in 0..tokens.len() {
                 for end in start..tokens.len() {
-                    data.set.fuzzy_match(&tokens[start..(end + 1)], 1, 1).unwrap();
+                    data.set.fuzzy_match(&tokens[start..(end + 1)], 1, 1, EndingType::NonPrefix).unwrap();
                 }
             }
         });
@@ -200,10 +200,10 @@ pub fn benchmark(c: &mut Criterion) {
 
         b.iter(|| {
             let tokens: Vec<_> = cycle.next().unwrap().split(" ").collect();
-            let mut variants: Vec<(Vec<&str>, bool)> = Vec::new();
+            let mut variants: Vec<(Vec<&str>, EndingType)> = Vec::new();
             for start in 0..tokens.len() {
                 for end in start..tokens.len() {
-                    variants.push((tokens[start..(end + 1)].to_vec(), false));
+                    variants.push((tokens[start..(end + 1)].to_vec(), EndingType::NonPrefix));
                 }
             }
             data.set.fuzzy_match_multi(variants.as_slice(), 1, 1).unwrap();
@@ -217,7 +217,7 @@ pub fn benchmark(c: &mut Criterion) {
 
         b.iter(|| {
             let tokens: Vec<_> = cycle.next().unwrap().split(" ").collect();
-            data.set.fuzzy_match_windows(tokens.as_slice(), 1, 1, false).unwrap();
+            data.set.fuzzy_match_windows(tokens.as_slice(), 1, 1, EndingType::NonPrefix).unwrap();
         });
     }));
 
@@ -247,10 +247,10 @@ pub fn benchmark(c: &mut Criterion) {
 
         b.iter(|| {
             let tokens: Vec<_> = cycle.next().unwrap().split(" ").collect();
-            let mut variants: Vec<(Vec<&str>, bool)> = Vec::new();
+            let mut variants: Vec<(Vec<&str>, EndingType)> = Vec::new();
             for start in 0..tokens.len() {
                 for end in start..tokens.len() {
-                    variants.push((tokens[start..(end + 1)].to_vec(), false));
+                    variants.push((tokens[start..(end + 1)].to_vec(), EndingType::NonPrefix));
                 }
             }
             data.set.fuzzy_match_multi(variants.as_slice(), 0, 0).unwrap();
@@ -264,7 +264,7 @@ pub fn benchmark(c: &mut Criterion) {
 
         b.iter(|| {
             let tokens: Vec<_> = cycle.next().unwrap().split(" ").collect();
-            data.set.fuzzy_match_windows(tokens.as_slice(), 0, 0, false).unwrap();
+            data.set.fuzzy_match_windows(tokens.as_slice(), 0, 0, EndingType::NonPrefix).unwrap();
         });
     }));
 

--- a/src/glue/enum_number.rs
+++ b/src/glue/enum_number.rs
@@ -12,8 +12,8 @@ macro_rules! enum_number {
             where
                 S: ::serde::Serializer,
             {
-                // Serialize the enum as a u32.
-                serializer.serialize_u32(*self as u32)
+                // Serialize the enum as a i64.
+                serializer.serialize_i64(*self as i64)
             }
         }
 
@@ -31,7 +31,7 @@ macro_rules! enum_number {
                         formatter.write_str("positive integer")
                     }
 
-                    fn visit_u32<E>(self, value: u32) -> Result<$name, E>
+                    fn visit_i64<E>(self, value: i64) -> Result<$name, E>
                     where
                         E: ::serde::de::Error,
                     {
@@ -46,8 +46,8 @@ macro_rules! enum_number {
                     }
                 }
 
-                // Deserialize the enum from a u32.
-                deserializer.deserialize_u32(Visitor)
+                // Deserialize the enum from a i64.
+                deserializer.deserialize_i64(Visitor)
             }
         }
     }

--- a/src/glue/enum_number.rs
+++ b/src/glue/enum_number.rs
@@ -1,0 +1,54 @@
+// from the serde docs - https://serde.rs/enum-number.html
+// with slight modifications
+macro_rules! enum_number {
+    ($name:ident { $($variant:ident = $value:expr, )* }) => {
+        #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+        pub enum $name {
+            $($variant = $value,)*
+        }
+
+        impl ::serde::Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: ::serde::Serializer,
+            {
+                // Serialize the enum as a u32.
+                serializer.serialize_u32(*self as u32)
+            }
+        }
+
+        impl<'de> ::serde::Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: ::serde::Deserializer<'de>,
+            {
+                struct Visitor;
+
+                impl<'de> ::serde::de::Visitor<'de> for Visitor {
+                    type Value = $name;
+
+                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                        formatter.write_str("positive integer")
+                    }
+
+                    fn visit_u32<E>(self, value: u32) -> Result<$name, E>
+                    where
+                        E: ::serde::de::Error,
+                    {
+                        // Rust does not come with a simple way of converting a
+                        // number to an enum, so use a big `match`.
+                        match value {
+                            $( $value => Ok($name::$variant), )*
+                            _ => Err(E::custom(
+                                format!("unknown {} value: {}",
+                                stringify!($name), value))),
+                        }
+                    }
+                }
+
+                // Deserialize the enum from a u32.
+                deserializer.deserialize_u32(Visitor)
+            }
+        }
+    }
+}

--- a/src/glue/fuzz_tests.rs
+++ b/src/glue/fuzz_tests.rs
@@ -69,6 +69,22 @@ fn glue_fuzztest_match_prefix() {
         if let Ok(res) = results {
             assert!(res.iter().filter(|result| phrase.starts_with(itertools::join(&result.phrase, " ").as_str())).count() > 0);
         }
+
+        let wb_results = SET.fuzzy_match_str(&damaged.as_str(), 1, 1, EndingType::WordBoundaryPrefix);
+        assert!(wb_results.is_ok());
+        if let Ok(res) = wb_results {
+            let prefix_match_results: Vec<_> = res.iter()
+                .filter(|result| phrase.starts_with(itertools::join(&result.phrase, " ").as_str()))
+                .collect();
+            // if the last word is complete, we should definitely match as above; if not, maybe maybe not
+            let words: Vec<_> = damaged.split(' ').collect();
+            let last_word = words.last().unwrap();
+            if &phrase.split(' ').nth(words.len() - 1).unwrap() == last_word {
+                assert!(prefix_match_results.len() > 0);
+            } else {
+                assert!(prefix_match_results.iter().all(|result| result.phrase.last().unwrap() == last_word || result.edit_distance > 0));
+            }
+        }
     }
 }
 

--- a/src/glue/mod.rs
+++ b/src/glue/mod.rs
@@ -1161,7 +1161,9 @@ mod basic_tests {
                 (vec!["100"], EndingType::NonPrefix),
                 (vec!["100", "main"], EndingType::NonPrefix),
                 (vec!["100", "main", "stre"], EndingType::AnyPrefix),
+                (vec!["100", "main", "stre"], EndingType::WordBoundaryPrefix),
                 (vec!["100", "main", "street"], EndingType::AnyPrefix),
+                (vec!["100", "main", "street"], EndingType::WordBoundaryPrefix),
                 (vec!["300"], EndingType::NonPrefix),
                 (vec!["300", "mlk"], EndingType::NonPrefix),
                 (vec!["300", "mlk", "blvd"], EndingType::AnyPrefix),
@@ -1170,6 +1172,8 @@ mod basic_tests {
                 vec![],
                 vec![],
                 vec![FuzzyMatchResult { phrase: vec!["100".to_string(), "main".to_string(), "stre".to_string()], edit_distance: 0, ending_type: EndingType::AnyPrefix }],
+                vec![],
+                vec![FuzzyMatchResult { phrase: vec!["100".to_string(), "main".to_string(), "street".to_string()], edit_distance: 0, ending_type: EndingType::WordBoundaryPrefix }],
                 vec![FuzzyMatchResult { phrase: vec!["100".to_string(), "main".to_string(), "street".to_string()], edit_distance: 0, ending_type: EndingType::WordBoundaryPrefix }],
                 vec![],
                 vec![],
@@ -1231,6 +1235,16 @@ mod basic_tests {
                 FuzzyWindowResult { phrase: vec!["St".to_string()], edit_distance: 1, start_position: 2, ending_type: EndingType::WordBoundaryPrefix }
             ]
         );
+        assert_eq!(
+            TEST_SET.fuzzy_match_windows(&["100", "main", "s"], 1, 1, EndingType::AnyPrefix).unwrap(),
+            vec![
+                FuzzyWindowResult { phrase: vec!["100".to_string(), "main".to_string(), "s".to_string()], edit_distance: 0, start_position: 0, ending_type: EndingType::AnyPrefix },
+            ]
+        );
+        assert_eq!(
+            TEST_SET.fuzzy_match_windows(&["100", "main", "s"], 1, 1, EndingType::WordBoundaryPrefix).unwrap(),
+            empty_struct
+        );
     }
 
     #[test]
@@ -1239,12 +1253,22 @@ mod basic_tests {
             TEST_SET.fuzzy_match_multi(&[
                 (vec!["100"], EndingType::NonPrefix),
                 (vec!["100", "main"], EndingType::NonPrefix),
-                (vec!["100", "main", "street"], EndingType::AnyPrefix)
+                (vec!["100", "main"], EndingType::WordBoundaryPrefix),
+                (vec!["100", "main", "stre"], EndingType::NonPrefix),
+                (vec!["100", "main", "stre"], EndingType::WordBoundaryPrefix),
+                (vec!["100", "main", "stre"], EndingType::AnyPrefix),
+                (vec!["100", "main", "street"], EndingType::WordBoundaryPrefix),
+                (vec!["100", "main", "street"], EndingType::AnyPrefix),
             ], 1, 1).unwrap(),
             vec![
                 TEST_SET.fuzzy_match(&["100"], 1, 1, EndingType::NonPrefix).unwrap(),
                 TEST_SET.fuzzy_match(&["100", "main"], 1, 1, EndingType::NonPrefix).unwrap(),
-                TEST_SET.fuzzy_match(&["100", "main", "street"], 1, 1, EndingType::AnyPrefix).unwrap()
+                TEST_SET.fuzzy_match(&["100", "main"], 1, 1, EndingType::WordBoundaryPrefix).unwrap(),
+                TEST_SET.fuzzy_match(&["100", "main", "stre"], 1, 1, EndingType::NonPrefix).unwrap(),
+                TEST_SET.fuzzy_match(&["100", "main", "stre"], 1, 1, EndingType::WordBoundaryPrefix).unwrap(),
+                TEST_SET.fuzzy_match(&["100", "main", "stre"], 1, 1, EndingType::AnyPrefix).unwrap(),
+                TEST_SET.fuzzy_match(&["100", "main", "street"], 1, 1, EndingType::WordBoundaryPrefix).unwrap(),
+                TEST_SET.fuzzy_match(&["100", "main", "street"], 1, 1, EndingType::AnyPrefix).unwrap(),
             ]
         );
     }

--- a/src/glue/mod.rs
+++ b/src/glue/mod.rs
@@ -18,6 +18,9 @@ use ::phrase::query::{QueryPhrase, QueryWord};
 use ::fuzzy::{FuzzyMap, FuzzyMapBuilder};
 use regex;
 
+use std::{str, fmt};
+#[macro_use] mod enum_number;
+
 pub mod unicode_ranges;
 mod util;
 
@@ -211,11 +214,12 @@ pub struct FuzzyPhraseSet {
     max_edit_distance: u8,
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Serialize, Deserialize)]
-pub enum EndingType {
-    NonPrefix = 0,
-    AnyPrefix = 1,
-    WordBoundaryPrefix = 2,
+enum_number! {
+    EndingType {
+        NonPrefix = 0,
+        AnyPrefix = 1,
+        WordBoundaryPrefix = 2,
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]

--- a/src/glue/mod.rs
+++ b/src/glue/mod.rs
@@ -211,10 +211,18 @@ pub struct FuzzyPhraseSet {
     max_edit_distance: u8,
 }
 
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Serialize, Deserialize)]
+pub enum EndingType {
+    NonPrefix = 0,
+    AnyPrefix = 1,
+    WordBoundaryPrefix = 2,
+}
+
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
 pub struct FuzzyMatchResult {
     pub edit_distance: u8,
     pub phrase: Vec<String>,
+    pub ending_type: EndingType,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
@@ -222,7 +230,7 @@ pub struct FuzzyWindowResult {
     pub edit_distance: u8,
     pub phrase: Vec<String>,
     pub start_position: usize,
-    pub ends_in_prefix: bool,
+    pub ending_type: EndingType,
 }
 
 impl<'a, 'b> PartialEq<FuzzyMatchResult> for FuzzyWindowResult {
@@ -311,68 +319,66 @@ impl FuzzyPhraseSet {
         util::can_fuzzy_match(word, &self.script_regex)
     }
 
-    pub fn contains<T: AsRef<str>>(&self, phrase: &[T]) -> Result<bool, Box<Error>> {
-        // strategy: get each word's ID from the prefix graph (or return false if any are missing)
-        // and then look up that ID sequence in the phrase graph
-        let mut id_phrase: Vec<QueryWord> = Vec::with_capacity(phrase.len());
-        for word in phrase {
-            match self.prefix_set.lookup(word.as_ref()).id() {
-                Some(word_id) => {
-                    let id = word_id.value() as u32;
-                    let maybe_replaced = *self.word_replacement_map.get(&id).unwrap_or(&id);
-                    id_phrase.push(QueryWord::new_full(maybe_replaced, 0))
-                },
-                None => { return Ok(false) }
+    pub fn contains<T: AsRef<str>>(&self, phrase: &[T], ending_type: EndingType) -> Result<bool, Box<Error>> {
+        match ending_type {
+            EndingType::NonPrefix | EndingType::WordBoundaryPrefix => {
+                // strategy: get each word's ID from the prefix graph (or return false if any are missing)
+                // and then look up that ID sequence in the phrase graph
+                let mut id_phrase: Vec<QueryWord> = Vec::with_capacity(phrase.len());
+                for word in phrase {
+                    match self.prefix_set.lookup(word.as_ref()).id() {
+                        Some(word_id) => {
+                            let id = word_id.value() as u32;
+                            let maybe_replaced = *self.word_replacement_map.get(&id).unwrap_or(&id);
+                            id_phrase.push(QueryWord::new_full(maybe_replaced, 0))
+                        },
+                        None => { return Ok(false) }
+                    }
+                }
+                Ok(match ending_type {
+                    EndingType::NonPrefix => self.phrase_set.contains(QueryPhrase::new(&id_phrase)?)?,
+                    _ => self.phrase_set.contains_prefix(QueryPhrase::new(&id_phrase)?)?
+                })
+            },
+            _ => {
+                // strategy: because of token replacement, the terminal word might have more than one
+                // possible word ID if the prefix range contains replaceable words; as such, rather
+                // than using PhraseSet's contains operation, we'll use the multi-path combination
+                // matcher as we do with fuzzy_match_prefix, but with a much-constrained search set
+                let mut word_possibilities: Vec<Vec<QueryWord>> = Vec::with_capacity(phrase.len());
+
+                if phrase.len() == 0 {
+                    return Ok(false);
+                }
+
+                let last_idx = phrase.len() - 1;
+                for word in phrase[..last_idx].iter() {
+                    match self.prefix_set.lookup(word.as_ref()).id() {
+                        Some(word_id) => {
+                            let id = word_id.value() as u32;
+                            let maybe_replaced = *self.word_replacement_map.get(&id).unwrap_or(&id);
+                            word_possibilities.push(vec![QueryWord::new_full(maybe_replaced, 0)])
+                        },
+                        None => { return Ok(false) }
+                    }
+                }
+                match self.get_terminal_word_possibilities(phrase[last_idx].as_ref(), 0)? {
+                    Some(possibilities) => word_possibilities.push(possibilities),
+                    None => return Ok(false),
+                }
+
+                let phrase_matches = self.phrase_set.match_combinations_as_prefixes(&word_possibilities, 0)?;
+                Ok(phrase_matches.len() > 0)
             }
         }
-        Ok(self.phrase_set.contains(QueryPhrase::new(&id_phrase)?)?)
     }
 
     // convenience method that splits the input string on the space character
     // IT DOES NOT DO PROPER TOKENIZATION; if you need that, use a real tokenizer and call
     // contains directly
-    pub fn contains_str(&self, phrase: &str) -> Result<bool, Box<Error>> {
+    pub fn contains_str(&self, phrase: &str, ending_type: EndingType) -> Result<bool, Box<Error>> {
         let phrase_v: Vec<&str> = phrase.split(' ').collect();
-        self.contains(&phrase_v)
-    }
-
-    pub fn contains_prefix<T: AsRef<str>>(&self, phrase: &[T]) -> Result<bool, Box<Error>> {
-        // strategy: because of token replacement, the terminal word might have more than one
-        // possible word ID if the prefix range contains replaceable words; as such, rather
-        // than using PhraseSet's contains operation, we'll use the multi-path combination
-        // matcher as we do with fuzzy_match_prefix, but with a much-constrained search set
-        let mut word_possibilities: Vec<Vec<QueryWord>> = Vec::with_capacity(phrase.len());
-
-        if phrase.len() == 0 {
-            return Ok(false);
-        }
-
-        let last_idx = phrase.len() - 1;
-        for word in phrase[..last_idx].iter() {
-            match self.prefix_set.lookup(word.as_ref()).id() {
-                Some(word_id) => {
-                    let id = word_id.value() as u32;
-                    let maybe_replaced = *self.word_replacement_map.get(&id).unwrap_or(&id);
-                    word_possibilities.push(vec![QueryWord::new_full(maybe_replaced, 0)])
-                },
-                None => { return Ok(false) }
-            }
-        }
-        match self.get_terminal_word_possibilities(phrase[last_idx].as_ref(), 0)? {
-            Some(possibilities) => word_possibilities.push(possibilities),
-            None => return Ok(false),
-        }
-
-        let phrase_matches = self.phrase_set.match_combinations_as_prefixes(&word_possibilities, 0)?;
-        Ok(phrase_matches.len() > 0)
-    }
-
-    // convenience method that splits the input string on the space character
-    // IT DOES NOT DO PROPER TOKENIZATION; if you need that, use a real tokenizer and call
-    // contains_prefix directly
-    pub fn contains_prefix_str(&self, phrase: &str) -> Result<bool, Box<Error>> {
-        let phrase_v: Vec<&str> = phrase.split(' ').collect();
-        self.contains_prefix(&phrase_v)
+        self.contains(&phrase_v, ending_type)
     }
 
     #[inline(always)]
@@ -458,7 +464,7 @@ impl FuzzyPhraseSet {
                 // replacement result; otherwise insert it into the set and push it to the output list
                 let already = last_variants.iter().any(|&x| match x {
                     QueryWord::Full { id, .. } => id == maybe_replaced,
-                    QueryWord::Prefix { id_range, .. } => maybe_replaced >= id_range.0 && maybe_replaced <= id_range.1 
+                    QueryWord::Prefix { id_range, .. } => maybe_replaced >= id_range.0 && maybe_replaced <= id_range.1
                 });
                 if !already {
                     last_variants.push(QueryWord::new_full(maybe_replaced, result.edit_distance));
@@ -472,59 +478,11 @@ impl FuzzyPhraseSet {
         }
     }
 
-    pub fn fuzzy_match<T: AsRef<str>>(&self, phrase: &[T], max_word_dist: u8, max_phrase_dist: u8) -> Result<Vec<FuzzyMatchResult>, Box<Error>> {
-        // strategy: look up each word in the fuzzy graph
-        // and then construct a vector of vectors representing all the word variants that could reside in each slot
-        // in the phrase, and then recursively enumerate every combination of variants and look them each up in the phrase graph
-
-        let mut word_possibilities: Vec<Vec<QueryWord>> = Vec::with_capacity(phrase.len());
-
-        let edit_distance = if max_word_dist > self.max_edit_distance {
-            return Err(Box::new(PhraseSetError::new(format!(
-                "The maximum configured edit distance for this index is {}; {} requested",
-                self.max_edit_distance,
-                max_word_dist
-            ).as_str())));
-        } else {
-            max_word_dist
-        };
-
-        // the map is executed lazily, so we can early-bail without correcting everything
-        for matches in phrase.iter().map(|word| self.get_nonterminal_word_possibilities(word.as_ref(), edit_distance)) {
-            match matches? {
-                Some(possibilities) => word_possibilities.push(possibilities),
-                None => return Ok(Vec::new()),
-            }
-        }
-
-        let phrase_matches = self.phrase_set.match_combinations(&word_possibilities, max_phrase_dist)?;
-
-        let mut results: Vec<FuzzyMatchResult> = Vec::new();
-        for phrase_p in &phrase_matches {
-            results.push(FuzzyMatchResult {
-                phrase: phrase_p.iter().map(|qw| match qw {
-                    QueryWord::Full { id, .. } => self.word_list[*id as usize].clone(),
-                    _ => panic!("prefixes not allowed"),
-                }).collect::<Vec<String>>(),
-                edit_distance: phrase_p.iter().map(|qw| match qw {
-                    QueryWord::Full { edit_distance, .. } => *edit_distance,
-                    _ => panic!("prefixes not allowed"),
-                }).sum(),
-            });
-        }
-
-        Ok(results)
-    }
-
-    pub fn fuzzy_match_str(&self, phrase: &str, max_word_dist: u8, max_phrase_dist: u8) -> Result<Vec<FuzzyMatchResult>, Box<Error>> {
-        let phrase_v: Vec<&str> = phrase.split(' ').collect();
-        self.fuzzy_match(&phrase_v, max_word_dist, max_phrase_dist)
-    }
-
-    pub fn fuzzy_match_prefix<T: AsRef<str>>(&self, phrase: &[T], max_word_dist: u8, max_phrase_dist: u8) -> Result<Vec<FuzzyMatchResult>, Box<Error>> {
+    pub fn fuzzy_match<T: AsRef<str>>(&self, phrase: &[T], max_word_dist: u8, max_phrase_dist: u8, ending_type: EndingType) -> Result<Vec<FuzzyMatchResult>, Box<Error>> {
         // strategy: look up each word in the fuzzy graph, and also look up the last one in the prefix graph
-        // and then construct a vector of vectors representing all the word variants that could reside in each slot
-        // in the phrase, and then recursively enumerate every combination of variants and look them each up in the phrase graph
+        // if the ending type allows for partial words (so, is AnyPrefix), and then construct a vector of
+        // vectors representing all the word variants that could reside in each slot in the phrase, and
+        // then recursively enumerate every combination of variants and look them each up in the phrase graph
 
         let mut word_possibilities: Vec<Vec<QueryWord>> = Vec::with_capacity(phrase.len());
 
@@ -544,19 +502,39 @@ impl FuzzyPhraseSet {
 
         // all words but the last one: fuzzy-lookup if eligible, or exact-match if not,
         // and return nothing if those fail
-        let last_idx = phrase.len() - 1;
-        for matches in phrase[..last_idx].iter().map(|word| self.get_nonterminal_word_possibilities(word.as_ref(), edit_distance)) {
-            match matches? {
-                Some(possibilities) => word_possibilities.push(possibilities),
-                None => return Ok(Vec::new()),
+        match ending_type {
+            EndingType::NonPrefix | EndingType::WordBoundaryPrefix => {
+                for matches in phrase.iter().map(|word| self.get_nonterminal_word_possibilities(word.as_ref(), edit_distance)) {
+                    match matches? {
+                        Some(possibilities) => word_possibilities.push(possibilities),
+                        None => return Ok(Vec::new()),
+                    }
+                }
+            },
+            EndingType::AnyPrefix => {
+                let last_idx = phrase.len() - 1;
+                for matches in phrase[..last_idx].iter().map(|word| self.get_nonterminal_word_possibilities(word.as_ref(), edit_distance)) {
+                    match matches? {
+                        Some(possibilities) => word_possibilities.push(possibilities),
+                        None => return Ok(Vec::new()),
+                    }
+                }
+                match self.get_terminal_word_possibilities(phrase[last_idx].as_ref(), edit_distance)? {
+                    Some(possibilities) => word_possibilities.push(possibilities),
+                    None => return Ok(Vec::new()),
+                }
             }
         }
-        match self.get_terminal_word_possibilities(phrase[last_idx].as_ref(), edit_distance)? {
-            Some(possibilities) => word_possibilities.push(possibilities),
-            None => return Ok(Vec::new()),
-        }
 
-        let phrase_matches = self.phrase_set.match_combinations_as_prefixes(&word_possibilities, max_phrase_dist)?;
+
+        let phrase_matches = match ending_type {
+            EndingType::NonPrefix => {
+                self.phrase_set.match_combinations(&word_possibilities, max_phrase_dist)?
+            },
+            EndingType::WordBoundaryPrefix | EndingType::AnyPrefix => {
+                self.phrase_set.match_combinations_as_prefixes(&word_possibilities, max_phrase_dist)?
+            }
+        };
 
         let mut results: Vec<FuzzyMatchResult> = Vec::new();
         for phrase_p in &phrase_matches {
@@ -569,18 +547,30 @@ impl FuzzyPhraseSet {
                     QueryWord::Full { edit_distance, .. } => *edit_distance,
                     QueryWord::Prefix { .. } => 0u8,
                 }).sum(),
+                ending_type: match ending_type {
+                    EndingType::NonPrefix | EndingType::WordBoundaryPrefix => ending_type,
+                    EndingType::AnyPrefix => {
+                        match phrase_p.last() {
+                            None => EndingType::NonPrefix,
+                            Some(qw) => match qw {
+                                QueryWord::Full { .. } => EndingType::WordBoundaryPrefix,
+                                QueryWord::Prefix { .. } => EndingType::AnyPrefix,
+                            }
+                        }
+                    }
+                }
             })
         }
 
         Ok(results)
     }
 
-    pub fn fuzzy_match_prefix_str(&self, phrase: &str, max_word_dist: u8, max_phrase_dist: u8) -> Result<Vec<FuzzyMatchResult>, Box<Error>> {
+    pub fn fuzzy_match_str(&self, phrase: &str, max_word_dist: u8, max_phrase_dist: u8, ending_type: EndingType) -> Result<Vec<FuzzyMatchResult>, Box<Error>> {
         let phrase_v: Vec<&str> = phrase.split(' ').collect();
-        self.fuzzy_match_prefix(&phrase_v, max_word_dist, max_phrase_dist)
+        self.fuzzy_match(&phrase_v, max_word_dist, max_phrase_dist, ending_type)
     }
 
-    pub fn fuzzy_match_windows<T: AsRef<str>>(&self, phrase: &[T], max_word_dist: u8, max_phrase_dist: u8, ends_in_prefix: bool) -> Result<Vec<FuzzyWindowResult>, Box<Error>> {
+    pub fn fuzzy_match_windows<T: AsRef<str>>(&self, phrase: &[T], max_word_dist: u8, max_phrase_dist: u8, ending_type: EndingType) -> Result<Vec<FuzzyWindowResult>, Box<Error>> {
         // this is a little different than the regular fuzzy match in that we're considering
         // multiple possible substrings we'll start by trying to fuzzy-match all the words, but
         // some of those will likely fail -- rather than early-returning like in regular fuzzy
@@ -616,7 +606,7 @@ impl FuzzyPhraseSet {
         #[derive(Debug)]
         struct Subquery {
             start_position: usize,
-            ends_in_prefix: bool,
+            ending_type: EndingType,
             word_possibilities: Vec<Vec<QueryWord>>
         }
         let mut subqueries: Vec<Subquery> = Vec::new();
@@ -632,24 +622,28 @@ impl FuzzyPhraseSet {
         };
 
         // this block creates an iterator of possible fuzzy matches for each word in phrase
-        let seq: Box<Iterator<Item=Result<Option<Vec<QueryWord>>, Box<Error>>>> = if ends_in_prefix {
-            // if the phrase ends in a prefix
-            let last_idx = phrase.len() - 1;
-            let i = phrase[..last_idx].iter().map(
-                // call this function on every word except the last one
-                |word| self.get_nonterminal_word_possibilities(word.as_ref(), edit_distance)
-            ).chain(iter::once(last_idx).map(
-                // call this function on the last word (the prefix)
-                |idx| self.get_terminal_word_possibilities(phrase[idx].as_ref(), edit_distance))
-            );
-            Box::new(i)
-        } else {
-            let i = phrase.iter().map(|word| self.get_nonterminal_word_possibilities(word.as_ref(), edit_distance));
-            Box::new(i)
+        let seq: Box<Iterator<Item=Result<Option<Vec<QueryWord>>, Box<Error>>>> = match ending_type {
+            EndingType::AnyPrefix => {
+                // if the phrase ends in an arbitrary prefix (so, final word could be partial)
+                let last_idx = phrase.len() - 1;
+                let i = phrase[..last_idx].iter().map(
+                    // call this function on every word except the last one
+                    |word| self.get_nonterminal_word_possibilities(word.as_ref(), edit_distance)
+                ).chain(iter::once(last_idx).map(
+                    // call this function on the last word (the prefix)
+                    |idx| self.get_terminal_word_possibilities(phrase[idx].as_ref(), edit_distance))
+                );
+                Box::new(i)
+            },
+            _ => {
+                // word either doesn't end in a prefix, or ends in a prefix we know is a full word
+                let i = phrase.iter().map(|word| self.get_nonterminal_word_possibilities(word.as_ref(), edit_distance));
+                Box::new(i)
+            }
         };
 
         // the sq variable starts off set to default variables.
-        let mut sq: Subquery = Subquery { start_position: 0, ends_in_prefix: false, word_possibilities: Vec::new() };
+        let mut sq: Subquery = Subquery { start_position: 0, ending_type: EndingType::NonPrefix, word_possibilities: Vec::new() };
 
         // Continuing with the example from above:
         //
@@ -679,13 +673,13 @@ impl FuzzyPhraseSet {
                     if sq.word_possibilities.len() > 0 {
                         // if the word_possibilities for the subquery built so far is non-empty,
                         // that means there's something to do
-                        if i == phrase.len() && ends_in_prefix {
-                            sq.ends_in_prefix = true;
+                        if i == phrase.len() {
+                            sq.ending_type = ending_type;
                         }
                         // push this subquery into the result array.
                         subqueries.push(sq);
                         // if reset the sq variable to the same default values after each loop.
-                        sq = Subquery { start_position: 0, ends_in_prefix: false, word_possibilities: Vec::new() };
+                        sq = Subquery { start_position: 0, ending_type: EndingType::NonPrefix, word_possibilities: Vec::new() };
                     }
                 },
             }
@@ -705,7 +699,10 @@ impl FuzzyPhraseSet {
                 let mut phrase_matches = self.phrase_set.match_combinations_as_windows(
                     &chunk.word_possibilities[i..],
                     max_phrase_dist,
-                    chunk.ends_in_prefix
+                    match chunk.ending_type {
+                        EndingType::NonPrefix => false,
+                        _ => true
+                    }
                 )?;
                 for (phrase_p, sq_ends_in_prefix) in &phrase_matches {
                     results.push(FuzzyWindowResult {
@@ -718,7 +715,21 @@ impl FuzzyPhraseSet {
                             QueryWord::Prefix { .. } => 0u8,
                         }).sum(),
                         start_position: chunk.start_position + i,
-                        ends_in_prefix: *sq_ends_in_prefix,
+                        ending_type: match sq_ends_in_prefix {
+                            false => EndingType::NonPrefix,
+                            true => match ending_type {
+                                EndingType::NonPrefix | EndingType::WordBoundaryPrefix => ending_type,
+                                EndingType::AnyPrefix => {
+                                    match phrase_p.last() {
+                                        None => EndingType::NonPrefix,
+                                        Some(qw) => match qw {
+                                            QueryWord::Full { .. } => EndingType::WordBoundaryPrefix,
+                                            QueryWord::Prefix { .. } => EndingType::AnyPrefix,
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     })
                 }
             }
@@ -727,7 +738,7 @@ impl FuzzyPhraseSet {
         Ok(results)
     }
 
-    pub fn fuzzy_match_multi<T: AsRef<str> + Ord + Debug, U: AsRef<[T]>>(&self, phrases: &[(U, bool)], max_word_dist: u8, max_phrase_dist: u8) -> Result<Vec<Vec<FuzzyMatchResult>>, Box<Error>> {
+    pub fn fuzzy_match_multi<T: AsRef<str> + Ord + Debug, U: AsRef<[T]>>(&self, phrases: &[(U, EndingType)], max_word_dist: u8, max_phrase_dist: u8) -> Result<Vec<Vec<FuzzyMatchResult>>, Box<Error>> {
 
         // This is roughly equivalent to `fuzzy_match_windows` in purpose, but operating under
         // the assumption that the caller will have wanted to make some changes to some of the
@@ -760,39 +771,42 @@ impl FuzzyPhraseSet {
 
         // fuzzy-lookup all the words, but only once apiece (per prefix-y-ness type)
         let mut all_words: FxHashMap<(&str, bool), Vec<QueryWord>> = FxHashMap::default();
-        let mut indexed_phrases: Vec<(&[T], bool, usize)> = Vec::new();
-        for (i, (phrase, ends_in_prefix)) in phrases.iter().enumerate() {
+        let mut indexed_phrases: Vec<(&[T], EndingType, usize)> = Vec::new();
+        for (i, (phrase, ending_type)) in phrases.iter().enumerate() {
             let phrase = phrase.as_ref();
-            if *ends_in_prefix {
-                let last_idx = phrase.len() - 1;
-                for word in phrase[..last_idx].iter() {
-                    let word = word.as_ref();
-                    if let hash_map::Entry::Vacant(entry) = all_words.entry((word, false)) {
+            match ending_type {
+                EndingType::AnyPrefix => {
+                    let last_idx = phrase.len() - 1;
+                    for word in phrase[..last_idx].iter() {
+                        let word = word.as_ref();
+                        if let hash_map::Entry::Vacant(entry) = all_words.entry((word, false)) {
+                            entry.insert(
+                                self.get_nonterminal_word_possibilities(word, edit_distance)?
+                                    .unwrap_or_else(|| Vec::with_capacity(0))
+                            );
+                        }
+                    }
+                    let last_word = phrase[last_idx].as_ref();
+                    if let hash_map::Entry::Vacant(entry) = all_words.entry((last_word, true)) {
                         entry.insert(
-                            self.get_nonterminal_word_possibilities(word, edit_distance)?
+                            self.get_terminal_word_possibilities(last_word, edit_distance)?
                                 .unwrap_or_else(|| Vec::with_capacity(0))
                         );
                     }
-                }
-                let last_word = phrase[last_idx].as_ref();
-                if let hash_map::Entry::Vacant(entry) = all_words.entry((last_word, true)) {
-                    entry.insert(
-                        self.get_terminal_word_possibilities(last_word, edit_distance)?
-                            .unwrap_or_else(|| Vec::with_capacity(0))
-                    );
-                }
-            } else {
-                for word in phrase.iter() {
-                    let word = word.as_ref();
-                    if let hash_map::Entry::Vacant(entry) = all_words.entry((word, false)) {
-                        entry.insert(
-                            self.get_nonterminal_word_possibilities(word, edit_distance)?
-                                .unwrap_or_else(|| Vec::with_capacity(0))
-                        );
+                },
+                EndingType::NonPrefix | EndingType::WordBoundaryPrefix => {
+                    for word in phrase.iter() {
+                        let word = word.as_ref();
+                        if let hash_map::Entry::Vacant(entry) = all_words.entry((word, false)) {
+                            entry.insert(
+                                self.get_nonterminal_word_possibilities(word, edit_distance)?
+                                    .unwrap_or_else(|| Vec::with_capacity(0))
+                            );
+                        }
                     }
                 }
             }
-            indexed_phrases.push((phrase, *ends_in_prefix, i));
+            indexed_phrases.push((phrase, *ending_type, i));
         }
 
         // First, `indexed_phrases` is sorted lexicographically according to the 0th member of each
@@ -811,7 +825,7 @@ impl FuzzyPhraseSet {
         indexed_phrases.sort();
 
         // Now we'll identify clusters of phrases consisting of a longest phrase together with
-        // shorter phrases that are prefixes of that longest phrase (and also not ends_with_prefix)
+        // shorter phrases that are prefixes of that longest phrase (and also not end in non-prefix)
         // so that we can just recurse over the phrase graph for the longest phrase and catch
         // any non-prefix-terminal shorter phrases along the way
         let mut collapsed: FxHashMap<usize, Vec<usize>> = FxHashMap::default();
@@ -824,7 +838,8 @@ impl FuzzyPhraseSet {
                 Some(peek) => {
                     // we're done with a group if...
                     // ...the current item ends in a prefix
-                    item.1 ||
+                    let ends_in_prefix = match item.1 { EndingType::NonPrefix => false, _ => true };
+                    ends_in_prefix ||
                         // ...or the next item is shorter than the current one, meaning the current
                         // one can't be a prefix of the next
                         peek.0.len() <= item.0.len() ||
@@ -852,7 +867,15 @@ impl FuzzyPhraseSet {
             // Reuse the possibilities vector
             word_possibilities.clear();
             let longest_phrase = &phrases[*longest_idx].0.as_ref();
-            let ends_in_prefix = phrases[*longest_idx].1;
+            let ending_type = phrases[*longest_idx].1;
+            let phrase_ends_in_prefix = match ending_type {
+                EndingType::NonPrefix => false,
+                _ => true
+            };
+            let final_word_ends_in_prefix = match ending_type {
+                EndingType::NonPrefix | EndingType::WordBoundaryPrefix => false,
+                _ => true
+            };
             for word in longest_phrase[..(longest_phrase.len() - 1)].iter() {
                 word_possibilities.push(
                     all_words.get(&(word.as_ref(), false))
@@ -860,14 +883,14 @@ impl FuzzyPhraseSet {
                 );
             }
             word_possibilities.push(
-                all_words.get(&(longest_phrase[longest_phrase.len() - 1].as_ref(), ends_in_prefix))
+                all_words.get(&(longest_phrase[longest_phrase.len() - 1].as_ref(), final_word_ends_in_prefix))
                     .ok_or("Can't find corrected word")?.clone()
             );
 
             let phrase_matches = self.phrase_set.match_combinations_as_windows(
                 &word_possibilities,
                 max_phrase_dist,
-                ends_in_prefix
+                phrase_ends_in_prefix
             )?;
 
             // Within this prefix cluster we have different things of different lengths and
@@ -875,7 +898,10 @@ impl FuzzyPhraseSet {
             // should be ascribed to their matching entries in the cluster so they can be inserted
             // into the right output slot.
             let length_map: FxHashMap<(usize, bool), usize> = all_idxes.iter().map(
-                |&idx| ((phrases[idx].0.as_ref().len(), phrases[idx].1), idx)
+                |&idx| ((phrases[idx].0.as_ref().len(), match phrases[idx].1 {
+                    EndingType::NonPrefix => false,
+                    _ => true
+                }), idx)
             ).collect();
 
             for (phrase_p, sq_ends_in_prefix) in &phrase_matches {
@@ -892,6 +918,21 @@ impl FuzzyPhraseSet {
                             QueryWord::Full { edit_distance, .. } => *edit_distance,
                             QueryWord::Prefix { .. } => 0u8,
                         }).sum(),
+                        ending_type: match sq_ends_in_prefix {
+                            false => EndingType::NonPrefix,
+                            true => match ending_type {
+                                EndingType::NonPrefix | EndingType::WordBoundaryPrefix => ending_type,
+                                EndingType::AnyPrefix => {
+                                    match phrase_p.last() {
+                                        None => EndingType::NonPrefix,
+                                        Some(qw) => match qw {
+                                            QueryWord::Full { .. } => EndingType::WordBoundaryPrefix,
+                                            QueryWord::Prefix { .. } => EndingType::AnyPrefix,
+                                        }
+                                    }
+                                }
+                            }
+                        },
                     });
                 }
             }
@@ -946,10 +987,10 @@ mod basic_tests {
     #[test]
     fn glue_contains() -> () {
         // contains
-        assert!(SET.contains_str("100 main street").unwrap());
-        assert!(SET.contains_str("200 main street").unwrap());
-        assert!(SET.contains_str("100 main ave").unwrap());
-        assert!(SET.contains_str("300 mlk blvd").unwrap());
+        assert!(SET.contains_str("100 main street", EndingType::NonPrefix).unwrap());
+        assert!(SET.contains_str("200 main street", EndingType::NonPrefix).unwrap());
+        assert!(SET.contains_str("100 main ave", EndingType::NonPrefix).unwrap());
+        assert!(SET.contains_str("300 mlk blvd", EndingType::NonPrefix).unwrap());
     }
 
     #[test]
@@ -957,112 +998,158 @@ mod basic_tests {
         // test that we're generic over vectors and arrays, and also Strings and strs
         // testing this for contains because it's simplest, but we reuse this pattern elsewhere,
         // e.g., for insert
-        assert!(SET.contains_str("100 main street").unwrap());
+        assert!(SET.contains_str("100 main street", EndingType::NonPrefix).unwrap());
         let phrase_static = ["100", "main", "street"];
-        assert!(SET.contains(&phrase_static).unwrap());
+        assert!(SET.contains(&phrase_static, EndingType::NonPrefix).unwrap());
         let phrase_vec: Vec<String> = vec!["100".to_string(), "main".to_string(), "street".to_string()];
-        assert!(SET.contains(&phrase_vec).unwrap());
+        assert!(SET.contains(&phrase_vec, EndingType::NonPrefix).unwrap());
         let ref_phrase_vec: Vec<&str> = phrase_vec.iter().map(|s| s.as_str()).collect();
-        assert!(SET.contains(&ref_phrase_vec).unwrap());
+        assert!(SET.contains(&ref_phrase_vec, EndingType::NonPrefix).unwrap());
     }
 
     #[test]
     fn glue_doesnt_contain() -> () {
-        assert!(!SET.contains_str("x").unwrap());
-        assert!(!SET.contains_str("100 main").unwrap());
-        assert!(!SET.contains_str("100 main s").unwrap());
-        assert!(!SET.contains_str("100 main streetr").unwrap());
-        assert!(!SET.contains_str("100 main street r").unwrap());
-        assert!(!SET.contains_str("100 main street ave").unwrap());
+        assert!(!SET.contains_str("x", EndingType::NonPrefix).unwrap());
+        assert!(!SET.contains_str("100 main", EndingType::NonPrefix).unwrap());
+        assert!(!SET.contains_str("100 main s", EndingType::NonPrefix).unwrap());
+        assert!(!SET.contains_str("100 main streetr", EndingType::NonPrefix).unwrap());
+        assert!(!SET.contains_str("100 main street r", EndingType::NonPrefix).unwrap());
+        assert!(!SET.contains_str("100 main street ave", EndingType::NonPrefix).unwrap());
     }
 
     #[test]
     fn glue_contains_prefix_exact() -> () {
         // contains prefix -- everything that works in full works as prefix
-        assert!(SET.contains_prefix_str("100 main street").unwrap());
-        assert!(SET.contains_prefix_str("200 main street").unwrap());
-        assert!(SET.contains_prefix_str("100 main ave").unwrap());
-        assert!(SET.contains_prefix_str("300 mlk blvd").unwrap());
+        assert!(SET.contains_str("100 main street", EndingType::AnyPrefix).unwrap());
+        assert!(SET.contains_str("200 main street", EndingType::AnyPrefix).unwrap());
+        assert!(SET.contains_str("100 main ave", EndingType::AnyPrefix).unwrap());
+        assert!(SET.contains_str("300 mlk blvd", EndingType::AnyPrefix).unwrap());
     }
 
     #[test]
     fn glue_contains_prefix_partial_word() -> () {
         // contains prefix -- drop a letter
-        assert!(SET.contains_prefix_str("100 main stree").unwrap());
-        assert!(SET.contains_prefix_str("200 main stree").unwrap());
-        assert!(SET.contains_prefix_str("100 main av").unwrap());
-        assert!(SET.contains_prefix_str("300 mlk blv").unwrap());
+        assert!(SET.contains_str("100 main stree", EndingType::AnyPrefix).unwrap());
+        assert!(SET.contains_str("200 main stree", EndingType::AnyPrefix).unwrap());
+        assert!(SET.contains_str("100 main av", EndingType::AnyPrefix).unwrap());
+        assert!(SET.contains_str("300 mlk blv", EndingType::AnyPrefix).unwrap());
+        // but not with word boundary matching
+        assert!(!SET.contains_str("100 main stree", EndingType::WordBoundaryPrefix).unwrap());
+        assert!(!SET.contains_str("200 main stree", EndingType::WordBoundaryPrefix).unwrap());
+        assert!(!SET.contains_str("100 main av", EndingType::WordBoundaryPrefix).unwrap());
+        assert!(!SET.contains_str("300 mlk blv", EndingType::WordBoundaryPrefix).unwrap());
     }
 
     #[test]
     fn glue_contains_prefix_dropped_word() -> () {
-        // contains prefix -- drop a word
-        assert!(SET.contains_prefix_str("100 main").unwrap());
-        assert!(SET.contains_prefix_str("200 main").unwrap());
-        assert!(SET.contains_prefix_str("100 main").unwrap());
-        assert!(SET.contains_prefix_str("300 mlk").unwrap());
+        // contains prefix -- drop a word; should work with both kinds of prefix matching
+        assert!(SET.contains_str("100 main", EndingType::AnyPrefix).unwrap());
+        assert!(SET.contains_str("200 main", EndingType::AnyPrefix).unwrap());
+        assert!(SET.contains_str("100 main", EndingType::AnyPrefix).unwrap());
+        assert!(SET.contains_str("300 mlk", EndingType::AnyPrefix).unwrap());
+        assert!(SET.contains_str("100 main", EndingType::WordBoundaryPrefix).unwrap());
+        assert!(SET.contains_str("200 main", EndingType::WordBoundaryPrefix).unwrap());
+        assert!(SET.contains_str("100 main", EndingType::WordBoundaryPrefix).unwrap());
+        assert!(SET.contains_str("300 mlk", EndingType::WordBoundaryPrefix).unwrap());
     }
 
     #[test]
     fn glue_doesnt_contain_prefix() -> () {
         // contains prefix -- drop a word
-        assert!(!SET.contains_prefix_str("100 man").unwrap());
-        assert!(!SET.contains_prefix_str("400 main").unwrap());
-        assert!(!SET.contains_prefix_str("100 main street x").unwrap());
+        assert!(!SET.contains_str("100 man", EndingType::AnyPrefix).unwrap());
+        assert!(!SET.contains_str("400 main", EndingType::AnyPrefix).unwrap());
+        assert!(!SET.contains_str("100 main street x", EndingType::AnyPrefix).unwrap());
+        assert!(!SET.contains_str("100 man", EndingType::WordBoundaryPrefix).unwrap());
+        assert!(!SET.contains_str("400 main", EndingType::WordBoundaryPrefix).unwrap());
+        assert!(!SET.contains_str("100 main street x", EndingType::WordBoundaryPrefix).unwrap());
     }
 
     #[test]
     fn glue_fuzzy_match() -> () {
         assert_eq!(
-            SET.fuzzy_match(&["100", "man", "street"], 1, 1).unwrap(),
+            SET.fuzzy_match(&["100", "man", "street"], 1, 1, EndingType::NonPrefix).unwrap(),
             vec![
-                FuzzyMatchResult { phrase: vec!["100".to_string(), "main".to_string(), "street".to_string()], edit_distance: 1 },
+                FuzzyMatchResult { phrase: vec!["100".to_string(), "main".to_string(), "street".to_string()], edit_distance: 1, ending_type: EndingType::NonPrefix },
             ]
         );
 
         assert_eq!(
-            SET.fuzzy_match(&["100", "man", "stret"], 1, 2).unwrap(),
+            SET.fuzzy_match(&["100", "man", "stret"], 1, 2, EndingType::NonPrefix).unwrap(),
             vec![
-                FuzzyMatchResult { phrase: vec!["100".to_string(), "main".to_string(), "street".to_string()], edit_distance: 2 },
+                FuzzyMatchResult { phrase: vec!["100".to_string(), "main".to_string(), "street".to_string()], edit_distance: 2, ending_type: EndingType::NonPrefix },
             ]
         );
 
-        assert!(SET.fuzzy_match(&["100", "man", "stret"], 2, 2).is_err());
+        assert!(SET.fuzzy_match(&["100", "man", "stret"], 2, 2, EndingType::NonPrefix).is_err());
     }
 
     #[test]
     fn glue_fuzzy_match_prefix() -> () {
         assert_eq!(
-            SET.fuzzy_match_prefix(&["100", "man"], 1, 1).unwrap(),
+            SET.fuzzy_match(&["100", "man"], 1, 1, EndingType::AnyPrefix).unwrap(),
             vec![
-                FuzzyMatchResult { phrase: vec!["100".to_string(), "main".to_string()], edit_distance: 1 },
+                FuzzyMatchResult { phrase: vec!["100".to_string(), "main".to_string()], edit_distance: 1, ending_type: EndingType::WordBoundaryPrefix },
             ]
         );
 
         assert_eq!(
-            SET.fuzzy_match_prefix(&["100", "man", "str"], 1, 1).unwrap(),
+            SET.fuzzy_match(&["100", "man"], 1, 1, EndingType::WordBoundaryPrefix).unwrap(),
             vec![
-                FuzzyMatchResult { phrase: vec!["100".to_string(), "main".to_string(), "str".to_string()], edit_distance: 1 },
+                FuzzyMatchResult { phrase: vec!["100".to_string(), "main".to_string()], edit_distance: 1, ending_type: EndingType::WordBoundaryPrefix },
             ]
         );
 
-        assert!(SET.fuzzy_match_prefix(&["100", "man"], 2, 1).is_err());
+        assert_eq!(
+            SET.fuzzy_match(&["100", "man", "str"], 1, 1, EndingType::AnyPrefix).unwrap(),
+            vec![
+                FuzzyMatchResult { phrase: vec!["100".to_string(), "main".to_string(), "str".to_string()], edit_distance: 1, ending_type: EndingType::AnyPrefix },
+            ]
+        );
+        assert_eq!(
+            SET.fuzzy_match(&["100", "man", "str"], 1, 1, EndingType::WordBoundaryPrefix).unwrap(),
+            vec![]
+        );
+
+        assert!(SET.fuzzy_match(&["100", "man"], 2, 1, EndingType::AnyPrefix).is_err());
     }
 
     #[test]
     fn glue_fuzzy_match_windows() -> () {
         assert_eq!(
-            SET.fuzzy_match_windows(&["100", "main", "street", "washington", "300"], 1, 1, true).unwrap(),
+            SET.fuzzy_match_windows(&["100", "main", "street", "washington", "30"], 1, 1, EndingType::AnyPrefix).unwrap(),
             vec![
-                FuzzyWindowResult { phrase: vec!["100".to_string(), "main".to_string(), "street".to_string()], edit_distance: 0, start_position: 0, ends_in_prefix: false },
-                FuzzyWindowResult { phrase: vec!["300".to_string()], edit_distance: 0, start_position: 4, ends_in_prefix: true }
+                FuzzyWindowResult { phrase: vec!["100".to_string(), "main".to_string(), "street".to_string()], edit_distance: 0, start_position: 0, ending_type: EndingType::NonPrefix },
+                FuzzyWindowResult { phrase: vec!["30".to_string()], edit_distance: 0, start_position: 4, ending_type: EndingType::AnyPrefix }
             ]
         );
 
         assert_eq!(
-            SET.fuzzy_match_windows(&["100", "main", "street", "washington", "300"], 1, 1, false).unwrap(),
+            SET.fuzzy_match_windows(&["100", "main", "street", "washington", "300"], 1, 1, EndingType::AnyPrefix).unwrap(),
             vec![
-                FuzzyWindowResult { phrase: vec!["100".to_string(), "main".to_string(), "street".to_string()], edit_distance: 0, start_position: 0, ends_in_prefix: false },
+                FuzzyWindowResult { phrase: vec!["100".to_string(), "main".to_string(), "street".to_string()], edit_distance: 0, start_position: 0, ending_type: EndingType::NonPrefix },
+                FuzzyWindowResult { phrase: vec!["300".to_string()], edit_distance: 0, start_position: 4, ending_type: EndingType::WordBoundaryPrefix }
+            ]
+        );
+
+        assert_eq!(
+            SET.fuzzy_match_windows(&["100", "main", "street", "washington", "30"], 1, 1, EndingType::WordBoundaryPrefix).unwrap(),
+            vec![
+                FuzzyWindowResult { phrase: vec!["100".to_string(), "main".to_string(), "street".to_string()], edit_distance: 0, start_position: 0, ending_type: EndingType::NonPrefix },
+            ]
+        );
+
+        assert_eq!(
+            SET.fuzzy_match_windows(&["100", "main", "street", "washington", "300"], 1, 1, EndingType::WordBoundaryPrefix).unwrap(),
+            vec![
+                FuzzyWindowResult { phrase: vec!["100".to_string(), "main".to_string(), "street".to_string()], edit_distance: 0, start_position: 0, ending_type: EndingType::NonPrefix },
+                FuzzyWindowResult { phrase: vec!["300".to_string()], edit_distance: 0, start_position: 4, ending_type: EndingType::WordBoundaryPrefix }
+            ]
+        );
+
+        assert_eq!(
+            SET.fuzzy_match_windows(&["100", "main", "street", "washington", "300"], 1, 1, EndingType::NonPrefix).unwrap(),
+            vec![
+                FuzzyWindowResult { phrase: vec!["100".to_string(), "main".to_string(), "street".to_string()], edit_distance: 0, start_position: 0, ending_type: EndingType::NonPrefix },
             ]
         );
     }
@@ -1071,20 +1158,22 @@ mod basic_tests {
     fn glue_fuzzy_match_multi() -> () {
         assert_eq!(
             SET.fuzzy_match_multi(&[
-                (vec!["100"], false),
-                (vec!["100", "main"], false),
-                (vec!["100", "main", "street"], true),
-                (vec!["300"], false),
-                (vec!["300", "mlk"], false),
-                (vec!["300", "mlk", "blvd"], true),
+                (vec!["100"], EndingType::NonPrefix),
+                (vec!["100", "main"], EndingType::NonPrefix),
+                (vec!["100", "main", "stre"], EndingType::AnyPrefix),
+                (vec!["100", "main", "street"], EndingType::AnyPrefix),
+                (vec!["300"], EndingType::NonPrefix),
+                (vec!["300", "mlk"], EndingType::NonPrefix),
+                (vec!["300", "mlk", "blvd"], EndingType::AnyPrefix),
             ], 1, 1).unwrap(),
             vec![
                 vec![],
                 vec![],
-                vec![FuzzyMatchResult { phrase: vec!["100".to_string(), "main".to_string(), "street".to_string()], edit_distance: 0 }],
+                vec![FuzzyMatchResult { phrase: vec!["100".to_string(), "main".to_string(), "stre".to_string()], edit_distance: 0, ending_type: EndingType::AnyPrefix }],
+                vec![FuzzyMatchResult { phrase: vec!["100".to_string(), "main".to_string(), "street".to_string()], edit_distance: 0, ending_type: EndingType::WordBoundaryPrefix }],
                 vec![],
                 vec![],
-                vec![FuzzyMatchResult { phrase: vec!["300".to_string(), "mlk".to_string(), "blvd".to_string()], edit_distance: 0 }]
+                vec![FuzzyMatchResult { phrase: vec!["300".to_string(), "mlk".to_string(), "blvd".to_string()], edit_distance: 0, ending_type: EndingType::WordBoundaryPrefix }]
             ]
         );
     }
@@ -1109,36 +1198,37 @@ mod basic_tests {
     #[test]
     fn fuzzy_match_windows() -> () {
         let empty_struct = Vec::<FuzzyWindowResult>::new();
-        //address present in the data, hence should match
+        // address present in the data, hence should match
+        // emits a word boundary prefix because there's exactly one termination and we matched it
         assert_eq!(
-            TEST_SET.fuzzy_match_windows(&["100", "main", "street"], 1, 1, true).unwrap(),
-            vec![FuzzyWindowResult { phrase: vec!["100".to_string(), "main".to_string(), "street".to_string()], edit_distance: 0, start_position: 0, ends_in_prefix: true }]
+            TEST_SET.fuzzy_match_windows(&["100", "main", "street"], 1, 1, EndingType::AnyPrefix).unwrap(),
+            vec![FuzzyWindowResult { phrase: vec!["100".to_string(), "main".to_string(), "street".to_string()], edit_distance: 0, start_position: 0, ending_type: EndingType::WordBoundaryPrefix }]
         );
         //address not present in the data, hence should not match
         assert_eq!(
-            TEST_SET.fuzzy_match_windows(&["0", "incorrect", "query"], 1, 1, true).unwrap(),
+            TEST_SET.fuzzy_match_windows(&["0", "incorrect", "query"], 1, 1, EndingType::AnyPrefix).unwrap(),
             empty_struct
         );
         //end of one address is the beginning of another address
         assert_eq!(
-            TEST_SET.fuzzy_match_windows(&["100", "main", "st"], 1, 1, false).unwrap(),
+            TEST_SET.fuzzy_match_windows(&["100", "main", "st"], 1, 1, EndingType::NonPrefix).unwrap(),
             vec![
-                FuzzyWindowResult { phrase: vec!["100".to_string(), "main".to_string(), "st".to_string()], edit_distance: 0, start_position: 0, ends_in_prefix: false }
+                FuzzyWindowResult { phrase: vec!["100".to_string(), "main".to_string(), "st".to_string()], edit_distance: 0, start_position: 0, ending_type: EndingType::NonPrefix }
             ]
         );
         //address contains words in another address
         assert_eq!(
-            TEST_SET.fuzzy_match_windows(&["100", "st", "washington"], 1, 1, false).unwrap(),
+            TEST_SET.fuzzy_match_windows(&["100", "st", "washington"], 1, 1, EndingType::NonPrefix).unwrap(),
             vec![
-                FuzzyWindowResult { phrase: vec!["100".to_string(), "st".to_string(), "washington".to_string()], edit_distance: 0, start_position: 0, ends_in_prefix: false }
+                FuzzyWindowResult { phrase: vec!["100".to_string(), "st".to_string(), "washington".to_string()], edit_distance: 0, start_position: 0, ending_type: EndingType::NonPrefix }
             ]
         );
         //autocomplete is applied only to the last term
         assert_eq!(
-            TEST_SET.fuzzy_match_windows(&["100", "main", "st"], 1, 1, true).unwrap(),
+            TEST_SET.fuzzy_match_windows(&["100", "main", "st"], 1, 1, EndingType::AnyPrefix).unwrap(),
             vec![
-                FuzzyWindowResult { phrase: vec!["100".to_string(), "main".to_string(), "st".to_string()], edit_distance: 0, start_position: 0, ends_in_prefix: true },
-                FuzzyWindowResult { phrase: vec!["St".to_string()], edit_distance: 1, start_position: 2, ends_in_prefix: true }
+                FuzzyWindowResult { phrase: vec!["100".to_string(), "main".to_string(), "st".to_string()], edit_distance: 0, start_position: 0, ending_type: EndingType::AnyPrefix },
+                FuzzyWindowResult { phrase: vec!["St".to_string()], edit_distance: 1, start_position: 2, ending_type: EndingType::WordBoundaryPrefix }
             ]
         );
     }
@@ -1147,14 +1237,14 @@ mod basic_tests {
     fn multi_search_fuzzy_match_equivalence() -> () {
         assert_eq!(
             TEST_SET.fuzzy_match_multi(&[
-                (vec!["100"], false),
-                (vec!["100", "main"], false),
-                (vec!["100", "main", "street"], true)
+                (vec!["100"], EndingType::NonPrefix),
+                (vec!["100", "main"], EndingType::NonPrefix),
+                (vec!["100", "main", "street"], EndingType::AnyPrefix)
             ], 1, 1).unwrap(),
             vec![
-                TEST_SET.fuzzy_match(&["100"], 1, 1).unwrap(),
-                TEST_SET.fuzzy_match(&["100", "main"], 1, 1).unwrap(),
-                TEST_SET.fuzzy_match(&["100", "main", "street"], 1, 1).unwrap()
+                TEST_SET.fuzzy_match(&["100"], 1, 1, EndingType::NonPrefix).unwrap(),
+                TEST_SET.fuzzy_match(&["100", "main"], 1, 1, EndingType::NonPrefix).unwrap(),
+                TEST_SET.fuzzy_match(&["100", "main", "street"], 1, 1, EndingType::AnyPrefix).unwrap()
             ]
         );
     }
@@ -1163,28 +1253,28 @@ mod basic_tests {
     fn one_char_skip() -> () {
         // confirm that we don't match e when we ask for d because of the one-char rule
         assert_eq!(
-            TEST_SET.fuzzy_match_windows(&["100", "d", "st"], 1, 1, true).unwrap(),
+            TEST_SET.fuzzy_match_windows(&["100", "d", "st"], 1, 1, EndingType::AnyPrefix).unwrap(),
             vec![
-                FuzzyWindowResult { phrase: vec!["100".to_string(), "d".to_string(), "st".to_string()], edit_distance: 0, start_position: 0, ends_in_prefix: true },
-                FuzzyWindowResult { phrase: vec!["St".to_string()], edit_distance: 1, start_position: 2, ends_in_prefix: true }
+                FuzzyWindowResult { phrase: vec!["100".to_string(), "d".to_string(), "st".to_string()], edit_distance: 0, start_position: 0, ending_type: EndingType::AnyPrefix },
+                FuzzyWindowResult { phrase: vec!["St".to_string()], edit_distance: 1, start_position: 2, ending_type: EndingType::WordBoundaryPrefix }
             ]
         );
 
         // same when it's in the terminal position
         assert_eq!(
-            TEST_SET.fuzzy_match_windows(&["100", "e"], 1, 1, true).unwrap(),
+            TEST_SET.fuzzy_match_windows(&["100", "e"], 1, 1, EndingType::AnyPrefix).unwrap(),
             vec![
-                FuzzyWindowResult { phrase: vec!["100".to_string(), "e".to_string()], edit_distance: 0, start_position: 0, ends_in_prefix: true },
+                FuzzyWindowResult { phrase: vec!["100".to_string(), "e".to_string()], edit_distance: 0, start_position: 0, ending_type: EndingType::WordBoundaryPrefix },
             ]
         );
 
         // and on multi
         assert_eq!(
             TEST_SET.fuzzy_match_multi(&[
-                (vec!["100", "e"], true),
+                (vec!["100", "e"], EndingType::AnyPrefix),
             ], 1, 1).unwrap(),
             vec![
-                vec![FuzzyMatchResult { phrase: vec!["100".to_string(), "e".to_string()], edit_distance: 0 }],
+                vec![FuzzyMatchResult { phrase: vec!["100".to_string(), "e".to_string()], edit_distance: 0, ending_type: EndingType::WordBoundaryPrefix }],
             ]
         );
     }

--- a/src/glue/mod.rs
+++ b/src/glue/mod.rs
@@ -348,7 +348,7 @@ impl FuzzyPhraseSet {
                 // strategy: because of token replacement, the terminal word might have more than one
                 // possible word ID if the prefix range contains replaceable words; as such, rather
                 // than using PhraseSet's contains operation, we'll use the multi-path combination
-                // matcher as we do with fuzzy_match_prefix, but with a much-constrained search set
+                // matcher as we do with fuzzy_match, but with a much-constrained search set
                 let mut word_possibilities: Vec<Vec<QueryWord>> = Vec::with_capacity(phrase.len());
 
                 if phrase.len() == 0 {
@@ -757,7 +757,7 @@ impl FuzzyPhraseSet {
         // The input is a slice of tuples of a phrase (slice of str-ish things) and a bool
         // representing ends_in_prefix-ness. The output here will be mapped positionally to the
         // input, so it'll be a vector of the same size as the input slice, where each position
-        // should contain the same results as a fuzzy_match or fuzzy_match_prefix of that phrase.
+        // should contain the same results as a fuzzy_match of that phrase.
 
         if phrases.len() == 0 {
             return Ok(Vec::new());

--- a/src/glue/replacement_tests.rs
+++ b/src/glue/replacement_tests.rs
@@ -190,12 +190,12 @@ fn get_terminal_word_possibilities() -> () {
 #[test]
 fn contains() {
     assert_eq!(
-        TEST_SET.contains_str("100 ft wayne rd").unwrap(),
+        TEST_SET.contains_str("100 ft wayne rd", EndingType::NonPrefix).unwrap(),
         true
     );
 
     assert_eq!(
-        TEST_SET.contains_str("100 fort wayne road").unwrap(),
+        TEST_SET.contains_str("100 fort wayne road", EndingType::NonPrefix).unwrap(),
         true
     );
 }
@@ -215,12 +215,12 @@ fn contains_prefix() {
         "100 f"
     ] {
         assert_eq!(
-            TEST_SET.contains_prefix_str(variant).unwrap(),
+            TEST_SET.contains_str(variant, EndingType::AnyPrefix).unwrap(),
             true
         );
     }
     assert_eq!(
-        TEST_SET.contains_prefix_str("100 q").unwrap(),
+        TEST_SET.contains_str("100 q", EndingType::AnyPrefix).unwrap(),
         false
     );
 }
@@ -230,60 +230,60 @@ fn fuzzy_match() {
     // match nothing -- the only way to get from s to st without prefixes is fuzzy matching,
     // and we don't fuzzy-match one-char words
     assert_eq!(
-        TEST_SET.fuzzy_match_str("100 main s", 1, 1).unwrap(),
+        TEST_SET.fuzzy_match_str("100 main s", 1, 1, EndingType::NonPrefix).unwrap(),
         vec![]
     );
 
     // exact-match to 100 main st at edit distance 0
     // also match 100 maine st since we're in budget if we don't have any other typos
     assert_eq!(
-        TEST_SET.fuzzy_match_str("100 main st", 1, 1).unwrap(),
+        TEST_SET.fuzzy_match_str("100 main st", 1, 1, EndingType::NonPrefix).unwrap(),
         vec![
-            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "main".to_string(), "st".to_string()] },
-            FuzzyMatchResult { edit_distance: 1, phrase: vec!["100".to_string(), "maine".to_string(), "st".to_string()] }
+            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "main".to_string(), "st".to_string()], ending_type: EndingType::NonPrefix },
+            FuzzyMatchResult { edit_distance: 1, phrase: vec!["100".to_string(), "maine".to_string(), "st".to_string()], ending_type: EndingType::NonPrefix }
         ]
     );
 
     // match to "100 main st" by fuzzy-matching, at distance 1
     assert_eq!(
-        TEST_SET.fuzzy_match_str("100 main str", 1, 1).unwrap(),
-        vec![FuzzyMatchResult { edit_distance: 1, phrase: vec!["100".to_string(), "main".to_string(), "st".to_string()] }]
+        TEST_SET.fuzzy_match_str("100 main str", 1, 1, EndingType::NonPrefix).unwrap(),
+        vec![FuzzyMatchResult { edit_distance: 1, phrase: vec!["100".to_string(), "main".to_string(), "st".to_string()], ending_type: EndingType::NonPrefix }]
     );
 
     // don't match anything if fuzzy search is disabled
     assert_eq!(
-        TEST_SET.fuzzy_match_str("100 main str", 0, 0).unwrap(),
+        TEST_SET.fuzzy_match_str("100 main str", 0, 0, EndingType::NonPrefix).unwrap(),
         vec![]
     );
 
     // match to nothing -- not doing prefix matching and too far to fuzzy match
     assert_eq!(
-        TEST_SET.fuzzy_match_str("100 main stre", 1, 1).unwrap(),
+        TEST_SET.fuzzy_match_str("100 main stre", 1, 1, EndingType::NonPrefix).unwrap(),
         vec![]
     );
 
     // match to "100 main street" by fuzzy-matching and then token-replace to "100 main st" at distance 1
     assert_eq!(
-        TEST_SET.fuzzy_match_str("100 main stree", 1, 1).unwrap(),
-        vec![FuzzyMatchResult { edit_distance: 1, phrase: vec!["100".to_string(), "main".to_string(), "st".to_string()] }]
+        TEST_SET.fuzzy_match_str("100 main stree", 1, 1, EndingType::NonPrefix).unwrap(),
+        vec![FuzzyMatchResult { edit_distance: 1, phrase: vec!["100".to_string(), "main".to_string(), "st".to_string()], ending_type: EndingType::NonPrefix }]
     );
 
     // exact-match to 100 main street and then replace, so match at edit distance 0
     // also match 100 maine st since we're in budget if we don't have any other typos
     assert_eq!(
-        TEST_SET.fuzzy_match_str("100 main street", 1, 1).unwrap(),
+        TEST_SET.fuzzy_match_str("100 main street", 1, 1, EndingType::NonPrefix).unwrap(),
         vec![
-            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "main".to_string(), "st".to_string()] },
-            FuzzyMatchResult { edit_distance: 1, phrase: vec!["100".to_string(), "maine".to_string(), "st".to_string()] }
+            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "main".to_string(), "st".to_string()], ending_type: EndingType::NonPrefix },
+            FuzzyMatchResult { edit_distance: 1, phrase: vec!["100".to_string(), "maine".to_string(), "st".to_string()], ending_type: EndingType::NonPrefix }
         ]
     );
 
     // make sure token replacements at not-the-end work as well
     for variant in vec!["100 fort wayne road", "100 ft wayne road", "100 fort wayne rd", "100 ft wayne rd"] {
         assert_eq!(
-            TEST_SET.fuzzy_match_str(variant, 1, 1).unwrap(),
+            TEST_SET.fuzzy_match_str(variant, 1, 1, EndingType::NonPrefix).unwrap(),
             vec![
-                FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "ft".to_string(), "wayne".to_string(), "rd".to_string()] }
+                FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "ft".to_string(), "wayne".to_string(), "rd".to_string()], ending_type: EndingType::NonPrefix }
             ]
         )
     }
@@ -294,84 +294,84 @@ fn fuzzy_match_prefix() {
     // match "100 main s" by prefix at edit distance 0, and since the s doesn't take up any budget,
     // also match "100 maine s"
     assert_eq!(
-        TEST_SET.fuzzy_match_prefix_str("100 main s", 1, 1).unwrap(),
+        TEST_SET.fuzzy_match_str("100 main s", 1, 1, EndingType::AnyPrefix).unwrap(),
         vec![
-            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "main".to_string(), "s".to_string()] },
-            FuzzyMatchResult { edit_distance: 1, phrase: vec!["100".to_string(), "maine".to_string(), "s".to_string()] }
+            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "main".to_string(), "s".to_string()], ending_type: EndingType::AnyPrefix },
+            FuzzyMatchResult { edit_distance: 1, phrase: vec!["100".to_string(), "maine".to_string(), "s".to_string()], ending_type: EndingType::AnyPrefix }
         ]
     );
 
     // exact-match to 100 main st at edit distance 0
     // also match 100 maine st since we're in budget if we don't have any other typos
     assert_eq!(
-        TEST_SET.fuzzy_match_prefix_str("100 main st", 1, 1).unwrap(),
+        TEST_SET.fuzzy_match_str("100 main st", 1, 1, EndingType::AnyPrefix).unwrap(),
         vec![
-            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "main".to_string(), "st".to_string()] },
-            FuzzyMatchResult { edit_distance: 1, phrase: vec!["100".to_string(), "maine".to_string(), "st".to_string()] }
+            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "main".to_string(), "st".to_string()], ending_type: EndingType::AnyPrefix },
+            FuzzyMatchResult { edit_distance: 1, phrase: vec!["100".to_string(), "maine".to_string(), "st".to_string()], ending_type: EndingType::AnyPrefix }
         ]
     );
 
     // match to "100 main st" by detecting replaceable prefix, at edit distance 0 (and maine)
     assert_eq!(
-        TEST_SET.fuzzy_match_prefix_str("100 main str", 1, 1).unwrap(),
+        TEST_SET.fuzzy_match_str("100 main str", 1, 1, EndingType::AnyPrefix).unwrap(),
         vec![
-            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "main".to_string(), "st".to_string()] },
-            FuzzyMatchResult { edit_distance: 1, phrase: vec!["100".to_string(), "maine".to_string(), "st".to_string()] }
+            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "main".to_string(), "st".to_string()], ending_type: EndingType::WordBoundaryPrefix },
+            FuzzyMatchResult { edit_distance: 1, phrase: vec!["100".to_string(), "maine".to_string(), "st".to_string()], ending_type: EndingType::WordBoundaryPrefix }
         ]
     );
 
     // omit maine but still match main if fuzzy search is disabled
     assert_eq!(
-        TEST_SET.fuzzy_match_prefix_str("100 main str", 0, 0).unwrap(),
+        TEST_SET.fuzzy_match_str("100 main str", 0, 0, EndingType::AnyPrefix).unwrap(),
         vec![
-            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "main".to_string(), "st".to_string()] },
+            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "main".to_string(), "st".to_string()], ending_type: EndingType::WordBoundaryPrefix },
         ]
     );
 
     // match to "100 main st" by detecting replaceable prefix, at edit distance 0 (and maine)
     assert_eq!(
-        TEST_SET.fuzzy_match_prefix_str("100 main stre", 1, 1).unwrap(),
+        TEST_SET.fuzzy_match_str("100 main stre", 1, 1, EndingType::AnyPrefix).unwrap(),
         vec![
-            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "main".to_string(), "st".to_string()] },
-            FuzzyMatchResult { edit_distance: 1, phrase: vec!["100".to_string(), "maine".to_string(), "st".to_string()] }
+            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "main".to_string(), "st".to_string()], ending_type: EndingType::WordBoundaryPrefix },
+            FuzzyMatchResult { edit_distance: 1, phrase: vec!["100".to_string(), "maine".to_string(), "st".to_string()], ending_type: EndingType::WordBoundaryPrefix }
         ]
     );
 
     // match to "100 main st" by detecting replaceable prefix, at edit distance 0 (and maine)
     assert_eq!(
-        TEST_SET.fuzzy_match_prefix_str("100 main stree", 1, 1).unwrap(),
+        TEST_SET.fuzzy_match_str("100 main stree", 1, 1, EndingType::AnyPrefix).unwrap(),
         vec![
-            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "main".to_string(), "st".to_string()] },
-            FuzzyMatchResult { edit_distance: 1, phrase: vec!["100".to_string(), "maine".to_string(), "st".to_string()] }
+            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "main".to_string(), "st".to_string()], ending_type: EndingType::WordBoundaryPrefix },
+            FuzzyMatchResult { edit_distance: 1, phrase: vec!["100".to_string(), "maine".to_string(), "st".to_string()], ending_type: EndingType::WordBoundaryPrefix }
         ]
     );
 
     // exact-match to 100 main street and then replace, so match at edit distance 0
     // also match 100 maine st since we're in budget if we don't have any other typos
     assert_eq!(
-        TEST_SET.fuzzy_match_prefix_str("100 main street", 1, 1).unwrap(),
+        TEST_SET.fuzzy_match_str("100 main street", 1, 1, EndingType::AnyPrefix).unwrap(),
         vec![
-            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "main".to_string(), "st".to_string()] },
-            FuzzyMatchResult { edit_distance: 1, phrase: vec!["100".to_string(), "maine".to_string(), "st".to_string()] }
+            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "main".to_string(), "st".to_string()], ending_type: EndingType::WordBoundaryPrefix },
+            FuzzyMatchResult { edit_distance: 1, phrase: vec!["100".to_string(), "maine".to_string(), "st".to_string()], ending_type: EndingType::WordBoundaryPrefix }
         ]
     );
 
     // this matches one thing that will be replaced and one thing that won't, but they both share
     // a prefix so just one thing comes out
     assert_eq!(
-        TEST_SET.fuzzy_match_prefix_str("100 f", 1, 1).unwrap(),
+        TEST_SET.fuzzy_match_str("100 f", 1, 1, EndingType::AnyPrefix).unwrap(),
         vec![
-            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "f".to_string()] }
+            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "f".to_string()], ending_type: EndingType::AnyPrefix }
         ]
     );
 
     // here they diverge: "fo" matches both "fort" (which will get replaced with "ft") and "fortenberry"
     // (which won't be replaced), so we need to emit both the regular prefix and the replacement
     assert_eq!(
-        TEST_SET.fuzzy_match_prefix_str("100 fo", 1, 1).unwrap(),
+        TEST_SET.fuzzy_match_str("100 fo", 1, 1, EndingType::AnyPrefix).unwrap(),
         vec![
-            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "fo".to_string()] },
-            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "ft".to_string()] }
+            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "fo".to_string()], ending_type: EndingType::AnyPrefix },
+            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "ft".to_string()], ending_type: EndingType::WordBoundaryPrefix }
         ]
     );
 
@@ -380,35 +380,35 @@ fn fuzzy_match_prefix() {
     // matter which -- we should see only one response, "100 ft" at distance 1 (and not fortenberry
     // at all)
     assert_eq!(
-        TEST_SET.fuzzy_match_prefix_str("100 frt", 1, 1).unwrap(),
+        TEST_SET.fuzzy_match_str("100 frt", 1, 1, EndingType::AnyPrefix).unwrap(),
         vec![
-            FuzzyMatchResult { edit_distance: 1, phrase: vec!["100".to_string(), "ft".to_string()] }
+            FuzzyMatchResult { edit_distance: 1, phrase: vec!["100".to_string(), "ft".to_string()], ending_type: EndingType::WordBoundaryPrefix }
         ]
     );
 
     // including the whole replaceable word behaves ~identically to including only its prefix
     assert_eq!(
-        TEST_SET.fuzzy_match_prefix_str("100 fort", 1, 1).unwrap(),
+        TEST_SET.fuzzy_match_str("100 fort", 1, 1, EndingType::AnyPrefix).unwrap(),
         vec![
-            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "fort".to_string()] },
-            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "ft".to_string()] }
+            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "fort".to_string()], ending_type: EndingType::AnyPrefix },
+            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "ft".to_string()], ending_type: EndingType::WordBoundaryPrefix }
         ]
     );
 
     // now we prefer fortenberry but also consider fort -> ft by fuzzy-match
     assert_eq!(
-        TEST_SET.fuzzy_match_prefix_str("100 forte", 1, 1).unwrap(),
+        TEST_SET.fuzzy_match_str("100 forte", 1, 1, EndingType::AnyPrefix).unwrap(),
         vec![
-            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "forte".to_string()] },
-            FuzzyMatchResult { edit_distance: 1, phrase: vec!["100".to_string(), "ft".to_string()] }
+            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "forte".to_string()], ending_type: EndingType::AnyPrefix },
+            FuzzyMatchResult { edit_distance: 1, phrase: vec!["100".to_string(), "ft".to_string()], ending_type: EndingType::WordBoundaryPrefix }
         ]
     );
 
     // now all that's left is fortenberry -- fort is too far away
     assert_eq!(
-        TEST_SET.fuzzy_match_prefix_str("100 forten", 1, 1).unwrap(),
+        TEST_SET.fuzzy_match_str("100 forten", 1, 1, EndingType::AnyPrefix).unwrap(),
         vec![
-            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "forten".to_string()] },
+            FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "forten".to_string()], ending_type: EndingType::AnyPrefix },
         ]
     );
 
@@ -422,9 +422,9 @@ fn fuzzy_match_prefix() {
         "100 ft wayne rd"
     ] {
         assert_eq!(
-            TEST_SET.fuzzy_match_prefix_str(variant, 1, 1).unwrap(),
+            TEST_SET.fuzzy_match_str(variant, 1, 1, EndingType::AnyPrefix).unwrap(),
             vec![
-                FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "ft".to_string(), "wayne".to_string(), "rd".to_string()] }
+                FuzzyMatchResult { edit_distance: 0, phrase: vec!["100".to_string(), "ft".to_string(), "wayne".to_string(), "rd".to_string()], ending_type: EndingType::WordBoundaryPrefix }
             ]
         )
     }
@@ -442,13 +442,13 @@ fn fuzzy_match_windows() -> () {
         "100 ft wayne rd"
     ] {
         assert_eq!(
-            TEST_SET.fuzzy_match_windows(&variant.split(' ').collect::<Vec<_>>(), 1, 1, true).unwrap(),
+            TEST_SET.fuzzy_match_windows(&variant.split(' ').collect::<Vec<_>>(), 1, 1, EndingType::AnyPrefix).unwrap(),
             vec![
                 FuzzyWindowResult {
                     edit_distance: 0,
                     phrase: vec!["100".to_string(), "ft".to_string(), "wayne".to_string(), "rd".to_string()],
                     start_position: 0,
-                    ends_in_prefix: true
+                    ending_type: EndingType::WordBoundaryPrefix
                 }
             ]
         )
@@ -461,13 +461,13 @@ fn fuzzy_match_windows() -> () {
         "100 ft wayne rd washington dc"
     ] {
         assert_eq!(
-            TEST_SET.fuzzy_match_windows(&variant.split(' ').collect::<Vec<_>>(), 1, 1, true).unwrap(),
+            TEST_SET.fuzzy_match_windows(&variant.split(' ').collect::<Vec<_>>(), 1, 1, EndingType::AnyPrefix).unwrap(),
             vec![
                 FuzzyWindowResult {
                     edit_distance: 0,
                     phrase: vec!["100".to_string(), "ft".to_string(), "wayne".to_string(), "rd".to_string()],
                     start_position: 0,
-                    ends_in_prefix: false
+                    ending_type: EndingType::NonPrefix
                 }
             ]
         )
@@ -480,13 +480,13 @@ fn fuzzy_match_windows() -> () {
         "washington dc 100 ft wayne rd"
     ] {
         assert_eq!(
-            TEST_SET.fuzzy_match_windows(&variant.split(' ').collect::<Vec<_>>(), 1, 1, true).unwrap(),
+            TEST_SET.fuzzy_match_windows(&variant.split(' ').collect::<Vec<_>>(), 1, 1, EndingType::AnyPrefix).unwrap(),
             vec![
                 FuzzyWindowResult {
                     edit_distance: 0,
                     phrase: vec!["100".to_string(), "ft".to_string(), "wayne".to_string(), "rd".to_string()],
                     start_position: 2,
-                    ends_in_prefix: true
+                    ending_type: EndingType::WordBoundaryPrefix
                 }
             ]
         )
@@ -494,19 +494,19 @@ fn fuzzy_match_windows() -> () {
 
     // make sure emitting multiple things works with replacement
     assert_eq!(
-        TEST_SET.fuzzy_match_windows(&["washington", "dc", "100", "fo"], 1, 1, true).unwrap(),
+        TEST_SET.fuzzy_match_windows(&["washington", "dc", "100", "fo"], 1, 1, EndingType::AnyPrefix).unwrap(),
         vec![
             FuzzyWindowResult {
                 edit_distance: 0,
                 phrase: vec!["100".to_string(), "fo".to_string()],
                 start_position: 2,
-                ends_in_prefix: true
+                ending_type: EndingType::AnyPrefix
             },
             FuzzyWindowResult {
                 edit_distance: 0,
                 phrase: vec!["100".to_string(), "ft".to_string()],
                 start_position: 2,
-                ends_in_prefix: true
+                ending_type: EndingType::WordBoundaryPrefix
             }
         ]
     );
@@ -516,48 +516,48 @@ fn fuzzy_match_windows() -> () {
 fn multi_search_fuzzy_match_equivalence() -> () {
     assert_eq!(
         TEST_SET.fuzzy_match_multi(&[
-            (vec!["100", "main", "s"], false),
-            (vec!["100", "main", "st"], false),
-            (vec!["100", "main", "str"], false),
-            (vec!["100", "main", "stre"], false),
-            (vec!["100", "main", "stree"], false),
-            (vec!["100", "main", "street"], false),
-            (vec!["100", "fort", "wayne", "road"], false),
-            (vec!["100", "ft", "wayne", "road"], false),
-            (vec!["100", "fort", "wayne", "rd"], false),
-            (vec!["100", "ft", "wayne", "rd"], false),
-            (vec!["100", "main", "s"], true),
-            (vec!["100", "main", "st"], true),
-            (vec!["100", "main", "str"], true),
-            (vec!["100", "main", "stre"], true),
-            (vec!["100", "main", "stree"], true),
-            (vec!["100", "main", "street"], true),
-            (vec!["100", "fort", "wayne", "road"], true),
-            (vec!["100", "ft", "wayne", "road"], true),
-            (vec!["100", "fort", "wayne", "rd"], true),
-            (vec!["100", "ft", "wayne", "rd"], true),
+            (vec!["100", "main", "s"], EndingType::NonPrefix),
+            (vec!["100", "main", "st"], EndingType::NonPrefix),
+            (vec!["100", "main", "str"], EndingType::NonPrefix),
+            (vec!["100", "main", "stre"], EndingType::NonPrefix),
+            (vec!["100", "main", "stree"], EndingType::NonPrefix),
+            (vec!["100", "main", "street"], EndingType::NonPrefix),
+            (vec!["100", "fort", "wayne", "road"], EndingType::NonPrefix),
+            (vec!["100", "ft", "wayne", "road"], EndingType::NonPrefix),
+            (vec!["100", "fort", "wayne", "rd"], EndingType::NonPrefix),
+            (vec!["100", "ft", "wayne", "rd"], EndingType::NonPrefix),
+            (vec!["100", "main", "s"], EndingType::AnyPrefix),
+            (vec!["100", "main", "st"], EndingType::AnyPrefix),
+            (vec!["100", "main", "str"], EndingType::AnyPrefix),
+            (vec!["100", "main", "stre"], EndingType::AnyPrefix),
+            (vec!["100", "main", "stree"], EndingType::AnyPrefix),
+            (vec!["100", "main", "street"], EndingType::AnyPrefix),
+            (vec!["100", "fort", "wayne", "road"], EndingType::AnyPrefix),
+            (vec!["100", "ft", "wayne", "road"], EndingType::AnyPrefix),
+            (vec!["100", "fort", "wayne", "rd"], EndingType::AnyPrefix),
+            (vec!["100", "ft", "wayne", "rd"], EndingType::AnyPrefix),
         ], 1, 1).unwrap(),
         vec![
-            TEST_SET.fuzzy_match(&["100", "main", "s"], 1, 1).unwrap(),
-            TEST_SET.fuzzy_match(&["100", "main", "st"], 1, 1).unwrap(),
-            TEST_SET.fuzzy_match(&["100", "main", "str"], 1, 1).unwrap(),
-            TEST_SET.fuzzy_match(&["100", "main", "stre"], 1, 1).unwrap(),
-            TEST_SET.fuzzy_match(&["100", "main", "stree"], 1, 1).unwrap(),
-            TEST_SET.fuzzy_match(&["100", "main", "street"], 1, 1).unwrap(),
-            TEST_SET.fuzzy_match(&["100", "fort", "wayne", "road"], 1, 1).unwrap(),
-            TEST_SET.fuzzy_match(&["100", "ft", "wayne", "road"], 1, 1).unwrap(),
-            TEST_SET.fuzzy_match(&["100", "fort", "wayne", "rd"], 1, 1).unwrap(),
-            TEST_SET.fuzzy_match(&["100", "ft", "wayne", "rd"], 1, 1).unwrap(),
-            TEST_SET.fuzzy_match_prefix(&["100", "main", "s"], 1, 1).unwrap(),
-            TEST_SET.fuzzy_match_prefix(&["100", "main", "st"], 1, 1).unwrap(),
-            TEST_SET.fuzzy_match_prefix(&["100", "main", "str"], 1, 1).unwrap(),
-            TEST_SET.fuzzy_match_prefix(&["100", "main", "stre"], 1, 1).unwrap(),
-            TEST_SET.fuzzy_match_prefix(&["100", "main", "stree"], 1, 1).unwrap(),
-            TEST_SET.fuzzy_match_prefix(&["100", "main", "street"], 1, 1).unwrap(),
-            TEST_SET.fuzzy_match_prefix(&["100", "fort", "wayne", "road"], 1, 1).unwrap(),
-            TEST_SET.fuzzy_match_prefix(&["100", "ft", "wayne", "road"], 1, 1).unwrap(),
-            TEST_SET.fuzzy_match_prefix(&["100", "fort", "wayne", "rd"], 1, 1).unwrap(),
-            TEST_SET.fuzzy_match_prefix(&["100", "ft", "wayne", "rd"], 1, 1).unwrap(),
+            TEST_SET.fuzzy_match(&["100", "main", "s"], 1, 1, EndingType::NonPrefix).unwrap(),
+            TEST_SET.fuzzy_match(&["100", "main", "st"], 1, 1, EndingType::NonPrefix).unwrap(),
+            TEST_SET.fuzzy_match(&["100", "main", "str"], 1, 1, EndingType::NonPrefix).unwrap(),
+            TEST_SET.fuzzy_match(&["100", "main", "stre"], 1, 1, EndingType::NonPrefix).unwrap(),
+            TEST_SET.fuzzy_match(&["100", "main", "stree"], 1, 1, EndingType::NonPrefix).unwrap(),
+            TEST_SET.fuzzy_match(&["100", "main", "street"], 1, 1, EndingType::NonPrefix).unwrap(),
+            TEST_SET.fuzzy_match(&["100", "fort", "wayne", "road"], 1, 1, EndingType::NonPrefix).unwrap(),
+            TEST_SET.fuzzy_match(&["100", "ft", "wayne", "road"], 1, 1, EndingType::NonPrefix).unwrap(),
+            TEST_SET.fuzzy_match(&["100", "fort", "wayne", "rd"], 1, 1, EndingType::NonPrefix).unwrap(),
+            TEST_SET.fuzzy_match(&["100", "ft", "wayne", "rd"], 1, 1, EndingType::NonPrefix).unwrap(),
+            TEST_SET.fuzzy_match(&["100", "main", "s"], 1, 1, EndingType::AnyPrefix).unwrap(),
+            TEST_SET.fuzzy_match(&["100", "main", "st"], 1, 1, EndingType::AnyPrefix).unwrap(),
+            TEST_SET.fuzzy_match(&["100", "main", "str"], 1, 1, EndingType::AnyPrefix).unwrap(),
+            TEST_SET.fuzzy_match(&["100", "main", "stre"], 1, 1, EndingType::AnyPrefix).unwrap(),
+            TEST_SET.fuzzy_match(&["100", "main", "stree"], 1, 1, EndingType::AnyPrefix).unwrap(),
+            TEST_SET.fuzzy_match(&["100", "main", "street"], 1, 1, EndingType::AnyPrefix).unwrap(),
+            TEST_SET.fuzzy_match(&["100", "fort", "wayne", "road"], 1, 1, EndingType::AnyPrefix).unwrap(),
+            TEST_SET.fuzzy_match(&["100", "ft", "wayne", "road"], 1, 1, EndingType::AnyPrefix).unwrap(),
+            TEST_SET.fuzzy_match(&["100", "fort", "wayne", "rd"], 1, 1, EndingType::AnyPrefix).unwrap(),
+            TEST_SET.fuzzy_match(&["100", "ft", "wayne", "rd"], 1, 1, EndingType::AnyPrefix).unwrap(),
         ]
     );
 }


### PR DESCRIPTION
This PR makes a bunch of changes around how prefix and non-prefix matching is described both on the input and output side.
- [x] Due to mediocre API planning, the first round of functions written in `glue` (`contains`, `fuzzy_match`) required specifying whether you wanted to only match full phrases or match phrase prefixes by calling different functions (e.g., `fuzzy_match` vs. `fuzzy_match_prefix`). The ones added later, `fuzzy_match_windows` and `fuzzy_match_multi`, instead used a single function and specified which you wanted via query param, since it was possible to potentially do both simultaneously with a single call. The early ones have now been adjusted to match the later ones' pattern, so `contains_prefix` and `fuzzy_match_prefix` are gone, in favor of an additional query param on `contains` and `fuzzy_match`, respectively
- [x] Those old functions used to accept prefix-ness as a boolean. Both they and the newly updated first-generation functions now accept it as a three-state enum, comprised of NonPrefix (equivalent to old false), AnyPrefix (equivalent to old true), and WordBoundaryPrefix, which allows matching phrase prefixes, but only at word boundaries. All functions have also been adapted to handle this additional case; effectively, they look up the last word as if it weren't in the prefix position (so, no partial word matching) but look up the resulting word list as a phrase prefix
- [x] All `glue` fuzzy lookup functions now also *return* the nature of the ending of their matches; the `window` lookup function did this already (via a boolean), whereas `fuzzy_match[_prefix]` and `fuzzy_match_multi` did not. They now all return using the same three-state enum. All NonPrefix lookups are guaranteed to return NonPrefix outputs. WordBoundaryPrefix lookups will return WordBoundaryPrefix outputs, or potentially also NonPrefix outputs given windowed matches that don't include the end of the query. AnyPrefix lookups may return AnyPrefix outputs (or NonPrefix outputs with windowed searches, as above), but may also return WordBoundaryPrefix matches in the event of a token replacement or spelling correction in the final word, or in some cases if the matcher determines that the final word is both a complete word and not a prefix of any other words.
- [x] All tests have been updated to pass input in using the new function signatures and expect/test output in the new format

Still to do:
- [x] Update the benchmarks -- these still use the old signatures so they don't compile at present
- [x] Add more tests with `WordBoundaryPrefix` inputs -- so far I've updated all the old tests that did either non-prefix or prefix matching to do NonPrefix or AnyPrefix matching, respectively, but I haven't yet added much in the way of tests specifically for the WordBoundary input behavior, which is new -- I'm waiting for codecov to come back on this branch to get a sense of what exactly needs attention

fixes #56 