### PR TITLE
Add mechanism for automatically binning phrases

### DIFF
--- a/src/glue/bin_tests.rs
+++ b/src/glue/bin_tests.rs
@@ -82,7 +82,7 @@ fn range_for_prefix(prefix: &str) -> Option<PrefixBin> {
         }
     }
     bounds.map(|(first, last)| PrefixBin {
-        prefix: prefix.to_string(),
+        prefix: prefix.trim().to_string(),
         first: Output::new(first as u64),
         last: Output::new(last as u64),
         size: last - first + 1
@@ -105,6 +105,36 @@ fn simple_division() {
         vec![
             range_for_prefix("r").unwrap(),
             range_for_prefix("sa").unwrap(),
+            range_for_prefix("sc").unwrap(),
+            range_for_prefix("se").unwrap(),
+            range_for_prefix("sh").unwrap(),
+            range_for_prefix("si").unwrap(),
+            range_for_prefix("so").unwrap(),
+            range_for_prefix("sp").unwrap(),
+            range_for_prefix("st").unwrap(),
+            range_for_prefix("su").unwrap(),
+            range_for_prefix("sy").unwrap(),
+        ]
+    );
+}
+
+#[test]
+fn reach_word_boundaries() {
+    // r's get split, some s's get further split, and the san's cross the word boundary
+    assert_eq!(
+        SET.get_prefix_bins(7).unwrap(),
+        vec![
+            range_for_prefix("ra").unwrap(),
+            range_for_prefix("re").unwrap(),
+            range_for_prefix("ri").unwrap(),
+            range_for_prefix("ro").unwrap(),
+            range_for_prefix("sac").unwrap(),
+            range_for_prefix("sai").unwrap(),
+            range_for_prefix("sal").unwrap(),
+            range_for_prefix("san ").unwrap(),
+            range_for_prefix("sand").unwrap(),
+            range_for_prefix("sant").unwrap(),
+            range_for_prefix("sav").unwrap(),
             range_for_prefix("sc").unwrap(),
             range_for_prefix("se").unwrap(),
             range_for_prefix("sh").unwrap(),

--- a/src/glue/bin_tests.rs
+++ b/src/glue/bin_tests.rs
@@ -1,0 +1,217 @@
+extern crate lazy_static;
+
+use fst::raw::Output;
+use super::bins::PrefixBin;
+use super::{FuzzyPhraseSetBuilder, FuzzyPhraseSet};
+
+lazy_static! {
+    static ref DIR: tempfile::TempDir = tempfile::tempdir().unwrap();
+    static ref CITIES: Vec<&'static str> = vec![
+        "raleigh north carolina",
+        "rancho cucamonga california",
+        "reno nevada",
+        "renton washington",
+        "rialto california",
+        "richardson texas",
+        "richmond california",
+        "richmond virginia",
+        "riverside california",
+        "rochester minnesota",
+        "rochester new york",
+        "rockford illinois",
+        "roseville california",
+        "round rock texas",
+        "sacramento california",
+        "saint paul minnesota",
+        "salem oregon",
+        "salinas california",
+        "salt lake city utah",
+        "san angelo texas",
+        "san antonio texas",
+        "san bernardino california",
+        "san diego california",
+        "san francisco california",
+        "san jose california",
+        "san mateo california",
+        "sandy springs georgia",
+        "santa ana california",
+        "santa clara california",
+        "santa clarita california",
+        "santa maria california",
+        "santa rosa california",
+        "savannah georgia",
+        "scottsdale arizona",
+        "seattle washington",
+        "shreveport louisiana",
+        "simi valley california",
+        "sioux falls south dakota",
+        "south bend indiana",
+        "sparks nevada",
+        "spokane washington",
+        "springfield illinois",
+        "springfield massachusetts",
+        "springfield missouri",
+        "st louis missouri",
+        "st petersburg florida",
+        "stamford connecticut",
+        "sterling heights michigan",
+        "stockton california",
+        "sugar land texas",
+        "sunnyvale california",
+        "surprise arizona",
+        "syracuse new york",
+    ];
+    static ref SET: FuzzyPhraseSet = {
+        let mut builder = FuzzyPhraseSetBuilder::new(&DIR.path()).unwrap();
+        for phrase in CITIES.iter() {
+            builder.insert_str(phrase).unwrap();
+        }
+        builder.finish().unwrap();
+        FuzzyPhraseSet::from_path(&DIR.path()).unwrap()
+    };
+}
+
+fn range_for_prefix(prefix: &str) -> Option<PrefixBin> {
+    let mut bounds = None;
+    for (i, phrase) in CITIES.iter().enumerate() {
+        if phrase.starts_with(prefix) {
+            bounds = match bounds {
+                None => Some((i, i)),
+                Some((j, _)) => Some((j, i))
+            };
+        }
+    }
+    bounds.map(|(first, last)| PrefixBin {
+        prefix: prefix.to_string(),
+        first: Output::new(first as u64),
+        last: Output::new(last as u64),
+        size: last - first + 1
+    })
+}
+
+#[test]
+fn unlimited_bins() {
+    assert_eq!(
+        SET.get_prefix_bins(std::usize::MAX).unwrap(),
+        vec![range_for_prefix("r").unwrap(), range_for_prefix("s").unwrap()]
+    );
+}
+
+#[test]
+fn simple_division() {
+    // r's stay together, s's have to get subidivided by one letter
+    assert_eq!(
+        SET.get_prefix_bins(20).unwrap(),
+        vec![
+            range_for_prefix("r").unwrap(),
+            range_for_prefix("sa").unwrap(),
+            range_for_prefix("sc").unwrap(),
+            range_for_prefix("se").unwrap(),
+            range_for_prefix("sh").unwrap(),
+            range_for_prefix("si").unwrap(),
+            range_for_prefix("so").unwrap(),
+            range_for_prefix("sp").unwrap(),
+            range_for_prefix("st").unwrap(),
+            range_for_prefix("su").unwrap(),
+            range_for_prefix("sy").unwrap(),
+        ]
+    );
+}
+
+#[test]
+fn cross_word_boundaries() {
+    // r's get split, some s's get further split, and the san's cross the word boundary
+    assert_eq!(
+        SET.get_prefix_bins(5).unwrap(),
+        vec![
+            range_for_prefix("ra").unwrap(),
+            range_for_prefix("re").unwrap(),
+            range_for_prefix("ri").unwrap(),
+            range_for_prefix("ro").unwrap(),
+            range_for_prefix("sac").unwrap(),
+            range_for_prefix("sai").unwrap(),
+            range_for_prefix("sal").unwrap(),
+            range_for_prefix("san a").unwrap(),
+            range_for_prefix("san b").unwrap(),
+            range_for_prefix("san d").unwrap(),
+            range_for_prefix("san f").unwrap(),
+            range_for_prefix("san j").unwrap(),
+            range_for_prefix("san m").unwrap(),
+            range_for_prefix("sand").unwrap(),
+            range_for_prefix("sant").unwrap(),
+            range_for_prefix("sav").unwrap(),
+            range_for_prefix("sc").unwrap(),
+            range_for_prefix("se").unwrap(),
+            range_for_prefix("sh").unwrap(),
+            range_for_prefix("si").unwrap(),
+            range_for_prefix("so").unwrap(),
+            range_for_prefix("sp").unwrap(),
+            range_for_prefix("st").unwrap(),
+            range_for_prefix("su").unwrap(),
+            range_for_prefix("sy").unwrap(),
+        ]
+    );
+}
+
+#[test]
+fn minimal_bins() {
+    // prefixes are now as long as they need to be to uniquely identify a single phrase
+    assert_eq!(
+        SET.get_prefix_bins(1).unwrap(),
+        vec![
+            range_for_prefix("ral").unwrap(),
+            range_for_prefix("ran").unwrap(),
+            range_for_prefix("reno").unwrap(),
+            range_for_prefix("rent").unwrap(),
+            range_for_prefix("ria").unwrap(),
+            range_for_prefix("richa").unwrap(),
+            range_for_prefix("richmond c").unwrap(),
+            range_for_prefix("richmond v").unwrap(),
+            range_for_prefix("riv").unwrap(),
+            range_for_prefix("rochester m").unwrap(),
+            range_for_prefix("rochester n").unwrap(),
+            range_for_prefix("rock").unwrap(),
+            range_for_prefix("ros").unwrap(),
+            range_for_prefix("rou").unwrap(),
+            range_for_prefix("sac").unwrap(),
+            range_for_prefix("sai").unwrap(),
+            range_for_prefix("sale").unwrap(),
+            range_for_prefix("sali").unwrap(),
+            range_for_prefix("salt").unwrap(),
+            range_for_prefix("san ang").unwrap(),
+            range_for_prefix("san ant").unwrap(),
+            range_for_prefix("san b").unwrap(),
+            range_for_prefix("san d").unwrap(),
+            range_for_prefix("san f").unwrap(),
+            range_for_prefix("san j").unwrap(),
+            range_for_prefix("san m").unwrap(),
+            range_for_prefix("sand").unwrap(),
+            range_for_prefix("santa a").unwrap(),
+            range_for_prefix("santa clara").unwrap(),
+            range_for_prefix("santa clari").unwrap(),
+            range_for_prefix("santa m").unwrap(),
+            range_for_prefix("santa r").unwrap(),
+            range_for_prefix("sav").unwrap(),
+            range_for_prefix("sc").unwrap(),
+            range_for_prefix("se").unwrap(),
+            range_for_prefix("sh").unwrap(),
+            range_for_prefix("sim").unwrap(),
+            range_for_prefix("sio").unwrap(),
+            range_for_prefix("so").unwrap(),
+            range_for_prefix("spa").unwrap(),
+            range_for_prefix("spo").unwrap(),
+            range_for_prefix("springfield i").unwrap(),
+            range_for_prefix("springfield ma").unwrap(),
+            range_for_prefix("springfield mi").unwrap(),
+            range_for_prefix("st l").unwrap(),
+            range_for_prefix("st p").unwrap(),
+            range_for_prefix("sta").unwrap(),
+            range_for_prefix("ste").unwrap(),
+            range_for_prefix("sto").unwrap(),
+            range_for_prefix("sug").unwrap(),
+            range_for_prefix("sun").unwrap(),
+            range_for_prefix("sur").unwrap(),
+            range_for_prefix("sy").unwrap(),
+        ]
+    );
+}

--- a/src/glue/bins.rs
+++ b/src/glue/bins.rs
@@ -3,7 +3,7 @@ use fst::raw::{Fst, Node, Output};
 
 use ::phrase::util::three_byte_decode;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PrefixBin {
     pub prefix: String,
     pub first: Output,

--- a/src/glue/bins.rs
+++ b/src/glue/bins.rs
@@ -1,0 +1,139 @@
+use itertools::Itertools;
+use fst::raw::{Fst, Node, Output};
+
+use ::phrase::util::three_byte_decode;
+
+#[derive(Debug, Clone)]
+pub struct PrefixBin {
+    pub prefix: String,
+    pub first: Output,
+    pub last: Output,
+    pub size: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct BinGroup<'a> {
+    pub prefix_bin: PrefixBin,
+    words: Vec<PrefixWord<'a>>
+}
+
+#[derive(Debug, Clone)]
+struct PrefixWord<'a> {
+    node: Node<'a>,
+    first: Output,
+    last: Output,
+    size: usize,
+    word_id: u32,
+}
+
+pub fn subdivide_word<'a>(fst: &'a Fst, word_root: &Node, id_base: Output, max_id_for_word: Output, max_bin_size: usize, word_list: &[String]) -> Vec<BinGroup<'a>> {
+    let mut naive_bins: Vec<BinGroup> = Vec::new();
+    let mut current_words: Vec<PrefixWord> = Vec::new();
+    let mut current_prefix: String = "".to_string();
+
+    if word_root.is_final() {
+        naive_bins.push(BinGroup {
+            prefix_bin: PrefixBin {
+                prefix: "".to_string(),
+                first: id_base,
+                last: id_base,
+                size: 1
+            },
+            words: Vec::new()
+        });
+    }
+
+    let mut transitions0 = word_root.transitions().peekable();
+    while let Some(t0) = transitions0.next() {
+        let min_output0 = id_base.cat(t0.out);
+        let max_output0 = match transitions0.peek() {
+            Some(next) => Output::new(id_base.cat(next.out).value() - 1),
+            None => max_id_for_word
+        };
+        let node1 = fst.node(t0.addr);
+        let mut transitions1 = node1.transitions().peekable();
+
+        while let Some(t1) = transitions1.next() {
+            let min_output1 = min_output0.cat(t1.out);
+            let max_output1 = match transitions1.peek() {
+                Some(next) => Output::new(min_output0.cat(next.out).value() - 1),
+                None => max_output0
+            };
+            let node2 = fst.node(t1.addr);
+            let mut transitions2 = node2.transitions().peekable();
+
+            while let Some(t2) = transitions2.next() {
+                let min_output2 = min_output1.cat(t2.out);
+                let max_output2 = match transitions2.peek() {
+                    Some(next) => Output::new(min_output1.cat(next.out).value() - 1),
+                    None => max_output1
+                };
+                let word_id = three_byte_decode(&[t0.inp, t1.inp, t2.inp]);
+                let word = &word_list[word_id as usize];
+                let prefix: String = word.chars().take(1).collect();
+                if prefix != current_prefix {
+                    if current_words.len() > 0 {
+                        let mut old_current_words = Vec::new();
+                        std::mem::swap(&mut current_words, &mut old_current_words);
+                        naive_bins.push(words_to_bin(current_prefix.clone(), old_current_words));
+                    }
+                    current_prefix = prefix;
+                }
+                current_words.push(PrefixWord {
+                    node: fst.node(t2.addr),
+                    first: min_output2,
+                    last: max_output2,
+                    size: (max_output2.value() - min_output2.value() + 1) as usize,
+                    word_id: word_id
+                });
+            }
+        }
+    }
+    if current_words.len() > 0 {
+        naive_bins.push(words_to_bin(current_prefix, current_words));
+    }
+
+    let mut out = Vec::new();
+    for bin in naive_bins.into_iter() {
+        if bin.prefix_bin.size > max_bin_size {
+            let subdivided = subdivide_bin(fst, &bin, 2, max_bin_size, word_list);
+            out.extend_from_slice(&subdivided);
+        } else {
+            out.push(bin);
+        }
+    }
+    out
+}
+
+fn subdivide_bin<'a>(fst: &'a Fst, bin: &BinGroup<'a>, depth: usize, max_bin_size: usize, word_list: &[String]) -> Vec<BinGroup<'a>> {
+    let rebinned = bin.words.iter().group_by(|w| word_list[w.word_id as usize].chars().take(depth).collect::<String>());
+    let mut out = Vec::new();
+    for (prefix, group) in rebinned.into_iter() {
+        let inner_bin = words_to_bin(prefix, group.cloned().collect());
+        if inner_bin.prefix_bin.size > max_bin_size {
+            if inner_bin.words.len() > 1 {
+                let subdivided = subdivide_bin(fst, &inner_bin, depth + 1, max_bin_size, word_list);
+                out.extend_from_slice(&subdivided);
+            } else {
+                let word = &inner_bin.words[0];
+                let subdivided = subdivide_word(fst, &word.node, word.first, word.last, max_bin_size, word_list);
+                let new_prefix = inner_bin.prefix_bin.prefix.rsplit(" ").nth(1).unwrap_or_else(|| "").to_string() + " " + &word_list[word.word_id as usize];
+                for mut sub_bin in subdivided {
+                    // our current inner_bin ends in a partial word that we're nuking, so pop that
+                    sub_bin.prefix_bin.prefix = ("".to_owned() + &new_prefix + " " + &sub_bin.prefix_bin.prefix).trim().to_string();
+                    out.push(sub_bin);
+                }
+            }
+        } else {
+            out.push(inner_bin);
+        }
+    }
+    out
+}
+
+fn words_to_bin(prefix: String, words: Vec<PrefixWord>) -> BinGroup {
+    let first = words[0].first;
+    let last = words.last().unwrap().last;
+    let size = (last.value() - first.value() + 1) as usize;
+    BinGroup { prefix_bin: PrefixBin { prefix, first, last, size }, words }
+}

--- a/src/glue/mod.rs
+++ b/src/glue/mod.rs
@@ -1374,4 +1374,5 @@ mod basic_tests {
 }
 
 #[cfg(test)] mod replacement_tests;
+#[cfg(test)] mod bin_tests;
 #[cfg(test)] mod fuzz_tests;

--- a/src/phrase/mod.rs
+++ b/src/phrase/mod.rs
@@ -541,7 +541,7 @@ impl PhraseSet {
                 let t2 = node2.transition(i2);
 
                 // we've got three bytes! woohoo!
-                let mut next_after_min = [t0.inp, t1.inp, t2.inp];
+                let next_after_min = [t0.inp, t1.inp, t2.inp];
 
                 if next_after_min <= sought_max_key {
                     // we found the first triple after the minimum,
@@ -682,6 +682,22 @@ impl PhraseSet {
                 }
             }
         }
+    }
+
+    pub fn as_fst(&self) -> &Fst {
+        &self.0
+    }
+
+    pub fn get_max_id(&self) -> Output {
+        // chase the maximum ID down the phrase tree
+        let mut max_node: Node = self.0.root();
+        let mut max_output: Output = Output::new(0);
+        while max_node.len() != 0 {
+            let t = max_node.transition(max_node.len() - 1);
+            max_output = max_output.cat(t.out);
+            max_node = self.0.node(t.addr);
+        }
+        max_output.cat(max_node.final_output())
     }
 
     /// Create from a raw byte sequence, which must be written by `PhraseSetBuilder`.


### PR DESCRIPTION
Carmen-cache had one entry per phrase in its index, and also had pre-aggregated combined "bins" with all the geodata for all phrases with a given prefix, to make short autocomplete operations faster. Carmen-core now uses the phrase IDs introduced in #71 rather than strings, so it doesn't have the necessary information to do this kind of pre-aggregation for short phrases. Initial iterations of carmen-core just bucketed data by ID numerically, without regard to how that mapped to actual shared prefixes in real words, and aggregated collections of these bins on the fly, combining them with some non-binned data if the bins didn't precisely align with real ID boundaries between prefixes. This turned out to be really slow at runtime.

This PR reintroduces a mechanism for communicating some information about which ID boundaries represent prefix boundaries, so that bins can be laid out optimally in carmen-core. Whereas carmen-cache had two levels of pre-combining, one for all three-character phrases and one for all six-character phrases, Carmen-core uses a single level of binning, but sizes bins dynamically (if bins are too large, relatively short prefixes will still be unable to use them, while if they're too small, you still need to combine lots to satisfy a query, and end up not gaining much by using them). This branch provides the mechanism necessary to get the information about where the bin boundaries should be, so that it can be communicated to carmen-core.

This is done by starting out with one bin for each single-character prefix, and then repeatedly subdividing all bins that are too large by adding an additional prefix letter (so, a one-character bin that's too big gets subdivided into many two-character bins). This is made somewhat more complicated by the fact that while conceptually from an outside perspective, each phrase is a single unit with a single ID, internally phrases are comprised of words which are comprised of characters, and characters are linked into words in one data structure while words are linked into phrases in another; the operation of "adding a character" to subdivide a phrase bin might do different things depending on whether or not we happen to be sitting at a word boundary.