### PR TITLE
turned codecov off per SEV-1 incident

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,6 @@ after_success: |
         # cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID
 
         # Uncomment the following two lines create and upload a report for codecov.io
-        cargo tarpaulin --out Xml
-        bash <(curl -s https://codecov.io/bash)
+#        cargo tarpaulin --out Xml
+#        bash <(curl -s https://codecov.io/bash)
     fi


### PR DESCRIPTION
Turns off codecov upload per guidance from Security, due to ongoing SEV-1 incident.

Commented off, as it looks like this has been toggled on and off in the past as well, and there is no indication that codecov will not be re-enabled at some point in the future.

cc. @aarthykc 